### PR TITLE
Added facebook registration and sign in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /log/*
 !/log/.keep
 /tmp
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -18,13 +18,18 @@ gem 'hashie'
 
 gem 'pg'
 
+gem 'koala'
+
 group :development, :test do
+  gem 'dotenv-rails'
   gem 'rspec-rails'
 end
 
 group :test do
   gem 'factory_girl_rails'
   gem 'oauth2'
+  gem 'vcr'
+  gem 'webmock'
 end
 
 # To use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.3.8)
     arel (6.0.3)
     bcrypt (3.1.10)
     builder (3.2.2)
@@ -52,9 +53,15 @@ GEM
       bcrypt
       email_validator (~> 1.4)
       rails (>= 3.1)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     doorkeeper (3.0.1)
       railties (>= 3.2)
+    dotenv (2.0.2)
+    dotenv-rails (2.0.2)
+      dotenv (= 2.0.2)
+      railties (~> 4.0)
     email_validator (1.6.0)
       activemodel
     erubis (2.7.0)
@@ -71,6 +78,10 @@ GEM
     i18n (0.7.0)
     json (1.8.3)
     jwt (1.5.1)
+    koala (2.2.0)
+      addressable
+      faraday
+      multi_json
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -139,6 +150,7 @@ GEM
       rspec-mocks (~> 3.3.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
+    safe_yaml (1.0.4)
     spring (1.4.0)
     sprockets (3.3.4)
       rack (~> 1.0)
@@ -150,6 +162,10 @@ GEM
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    vcr (2.9.3)
+    webmock (1.21.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
 
 PLATFORMS
   ruby
@@ -158,8 +174,10 @@ DEPENDENCIES
   active_model_serializers!
   clearance
   doorkeeper
+  dotenv-rails
   factory_girl_rails
   hashie
+  koala
   oauth2
   pg
   rack-cors
@@ -167,6 +185,8 @@ DEPENDENCIES
   rails-api
   rspec-rails
   spring
+  vcr
+  webmock
 
 BUNDLED WITH
    1.10.6

--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -1,16 +1,47 @@
 class TokensController < Doorkeeper::TokensController
 
   def create
-    response = strategy.authorize
-    user_id = response.try(:token).try(:resource_owner_id)
-    if user_id
-      user = User.find(user_id)
+    if params[:facebook_auth_code]
+      access_token_info = facebook_oauth.get_access_token_info(params[:facebook_auth_code])
+      facebook_access_token = access_token_info["access_token"] || JSON.parse(access_token_info.keys[0])["access_token"]
+      graph = Koala::Facebook::API.new(facebook_access_token, ENV["FACEBOOK_APP_SECRET"])
+      facebook_user = graph.get_object("me", { fields: 'email, name'})
+
+      user = User.where("facebook_id = ? OR email = ?", facebook_user["id"], facebook_user["email"]).first_or_create.tap do |u|
+        u.email = facebook_user["email"] unless u.email.present?
+        u.facebook_id = facebook_user["id"]
+        u.facebook_access_token = facebook_access_token
+        u.password = User.friendly_token unless u.encrypted_password.present?
+        u.save!
+      end
+
+      doorkeeper_access_token = Doorkeeper::AccessToken.create!(application_id: nil, resource_owner_id: user.id, expires_in: 7200)
+
+      token_data = {
+        access_token: doorkeeper_access_token.token,
+        token_type: "bearer",
+        expires_in: doorkeeper_access_token.expires_in,
+        user_id: user.id.to_s,
+      }
+
+      render json: token_data.to_json, status: :ok
+    else
+      response = strategy.authorize
+      user_id = response.try(:token).try(:resource_owner_id)
+      body = response.body.merge("user_id" => user_id)
+      if user_id
+        user = User.find(user_id)
+      end
+      self.headers.merge! response.headers
+      self.response_body = body.to_json
+      self.status = response.status
     end
-    self.headers.merge! response.headers
-    self.response_body = body.to_json
-    self.status = response.status
   rescue Doorkeeper::Errors::DoorkeeperError, Doorkeeper::OAuth::Error => e
     handle_token_exception e
+  end
+
+  def facebook_oauth
+    @facebook_oauth ||= Koala::Facebook::OAuth.new(ENV["FACEBOOK_APP_ID"], ENV["FACEBOOK_APP_SECRET"], ENV["FACEBOOK_REDIRECT_URL"])
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,8 @@
 class User < ActiveRecord::Base
   include Clearance::User
+
+  def self.friendly_token
+    # Borrowed from Devise.friendly_token
+    SecureRandom.urlsafe_base64(15).tr('lIO0', 'sxyz').first(12)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
 
-  use_doorkeeper
+  use_doorkeeper do
+    controllers tokens: 'tokens'
+  end
 
   constraints subdomain: 'api' do
     get 'ping', to: 'ping#index'

--- a/db/migrate/20150924131807_add_facebook_id_to_user.rb
+++ b/db/migrate/20150924131807_add_facebook_id_to_user.rb
@@ -1,0 +1,5 @@
+class AddFacebookIdToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :facebook_id, :string
+  end
+end

--- a/db/migrate/20150924131823_add_facebook_access_token_to_user.rb
+++ b/db/migrate/20150924131823_add_facebook_access_token_to_user.rb
@@ -1,0 +1,5 @@
+class AddFacebookAccessTokenToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :facebook_access_token, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150924091555) do
+ActiveRecord::Schema.define(version: 20150924131823) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,9 +60,11 @@ ActiveRecord::Schema.define(version: 20150924091555) do
     t.string "first_name"
     t.string "last_name"
     t.string "email"
-    t.string "encrypted_password", limit: 128
-    t.string "confirmation_token", limit: 128
-    t.string "remember_token",     limit: 128
+    t.string "encrypted_password",    limit: 128
+    t.string "confirmation_token",    limit: 128
+    t.string "remember_token",        limit: 128
+    t.string "facebook_id"
+    t.text   "facebook_access_token"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", using: :btree

--- a/spec/requests/api/tokens_spec.rb
+++ b/spec/requests/api/tokens_spec.rb
@@ -12,7 +12,6 @@ describe "Tokens API" do
           username: 'existing-user@mail.com',
           password: 'test_password'
         }
-
         expect(last_response.status).to eq 200
         expect(json.access_token).not_to be nil
       end
@@ -28,6 +27,7 @@ describe "Tokens API" do
         expect(last_response.status).to eq 401
         expect(json.error).to eq 'invalid_grant'
       end
+
       it "fails with 401 when password is invalid" do
         create(:user, email: 'existing-user@mail.com', password: 'test_password')
         post "#{host}/oauth/token", {
@@ -39,6 +39,70 @@ describe "Tokens API" do
         expect(last_response.status).to eq 401
         expect(json.error).to eq 'invalid_grant'
       end
+
+    end
+
+    context "with a facebook_auth_code" do
+
+      before do
+        oauth = Koala::Facebook::OAuth.new(ENV["FACEBOOK_APP_ID"], ENV["FACEBOOK_APP_SECRET"], ENV["FACEBOOK_REDIRECT_URL"])
+        test_users = Koala::Facebook::TestUsers.new(app_id: ENV["FACEBOOK_APP_ID"], secret: ENV["FACEBOOK_APP_SECRET"])
+        @facebook_user = test_users.create(true, "email")
+        short_lived_token = @facebook_user["access_token"]
+        long_lived_token_info = oauth.exchange_access_token_info(short_lived_token)
+        @facebook_auth_code = oauth.generate_client_code(long_lived_token_info["access_token"])
+      end
+
+      context "when the user does not already exist" do
+
+        it 'creates a user from Facebook and returns a token', vcr: { cassette_name: 'requests/api/tokens/creates a user' } do
+          post "#{host}/oauth/token", {
+            facebook_auth_code: @facebook_auth_code
+          }
+          expect(last_response.status).to eq 200
+
+          expect(json.access_token).to_not be_nil
+          expect(json.user_id).to_not be_nil
+          expect(json.expires_in).to eq 7200
+          expect(json.token_type).to eq "bearer"
+        end
+
+      end
+
+      context "when the user already exists" do
+
+        context "with just the same email" do
+          it 'updates the user from Facebook and returns a token', vcr: { cassette_name: 'requests/api/tokens/creates a user' } do
+            user = create(:user, email: @facebook_user["email"], facebook_id: nil)
+
+            post "#{host}/oauth/token", { facebook_auth_code: @facebook_auth_code }
+
+            expect(last_response.status).to eq 200
+
+            expect(json.access_token).to_not be_nil
+            expect(json.user_id).to eq user.id.to_s
+            expect(json.expires_in).to eq 7200
+            expect(json.token_type).to eq "bearer"
+          end
+        end
+
+        context "with just the same facebook_id" do
+          it 'updates the user from Facebook and returns a token', vcr: { cassette_name: 'requests/api/tokens/creates a user' } do
+            user = create(:user, email: "different@email.com", facebook_id: @facebook_user["id"])
+
+            post "#{host}/oauth/token", { facebook_auth_code: @facebook_auth_code }
+
+            expect(last_response.status).to eq 200
+
+            expect(json.access_token).to_not be_nil
+            expect(json.user_id).to eq user.id.to_s
+            expect(json.expires_in).to eq 7200
+            expect(json.token_type).to eq "bearer"
+          end
+        end
+
+      end
+
     end
 
   end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,0 +1,16 @@
+VCR.configure do |c|
+  c.cassette_library_dir = Rails.root.join("spec", "vcr")
+  c.hook_into :webmock
+  c.configure_rspec_metadata!
+
+  # Uncomment for debugging VCR
+  # c.debug_logger = File.open('log/test.log', 'w')
+
+  c.ignore_request do |request|
+    URI(request.uri).host == '127.0.0.1'
+  end
+
+  c.default_cassette_options = { :serialize_with => :psych }
+
+  ignore_localhost = true
+end

--- a/spec/vcr/requests/api/tokens/creates_a_user.yml
+++ b/spec/vcr/requests/api/tokens/creates_a_user.yml
@@ -1,0 +1,294 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://graph.facebook.com/oauth/access_token
+    body:
+      encoding: UTF-8
+      string: client_id=1125363250824366&client_secret=25b9c58e996fe09a1d4d2b243157b9f6&grant_type=client_credentials
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/plain; charset=UTF-8
+      X-Fb-Trace-Id:
+      - B3Yq5474Nou
+      X-Fb-Rev:
+      - '1953636'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Facebook-Api-Version:
+      - v2.0
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      X-Fb-Debug:
+      - PuSjNaD3YpFB0sRHmqo5XrjvEe5hloBldFvLQjlB9pOgZzH9yl1KD4QqnYheSjSZYLzBnVkX891BpB3z9JsXXQ==
+      Date:
+      - Thu, 24 Sep 2015 14:37:51 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '57'
+    body:
+      encoding: UTF-8
+      string: access_token=1125363250824366|yCSpq5nr3OAsGEH2pul0XixzaSc
+    http_version: 
+  recorded_at: Thu, 24 Sep 2015 14:38:09 GMT
+- request:
+    method: post
+    uri: https://graph.facebook.com/1125363250824366/accounts/test-users
+    body:
+      encoding: UTF-8
+      string: access_token=1125363250824366%7CyCSpq5nr3OAsGEH2pul0XixzaSc&installed=true&permissions=email
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Fb-Trace-Id:
+      - DID0RweiND/
+      X-Fb-Rev:
+      - '1953636'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Facebook-Api-Version:
+      - v2.4
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      X-Fb-Debug:
+      - pMg7JsVO/KrJpU6vStG6SJCDLhWCTa400Ypl4sVSC4tvfJnOdKswRLW+cLqlqcfVQvbU36OPiyIyJ5ul8rnt3g==
+      Date:
+      - Thu, 24 Sep 2015 14:37:55 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '421'
+    body:
+      encoding: UTF-8
+      string: '{"id":"138525189831376","access_token":"CAAPZCgwzPBK4BADC6GXZCBntOEhqZCrwxacdjmfKxLdibgv9j8pKAMpnOQFswkAFJ2ZADUdjgZCviM8VpAnuChv200qXIEgiSMZCHNnX91cyDReuqmjX1mL7IJs0ULPfEhmZAT7ubDObADUFkoUZAtONzlf2ofMZAZA7aUdvnZAFmw4m7OqziAIypMBKU9LZCkxly6MZD","login_url":"https:\/\/developers.facebook.com\/checkpoint\/test-user-login\/138525189831376\/","email":"giabvhz_martinazzison_1443105472\u0040tfbnw.net","password":"823387522"}'
+    http_version: 
+  recorded_at: Thu, 24 Sep 2015 14:38:12 GMT
+- request:
+    method: post
+    uri: https://graph.facebook.com/oauth/access_token
+    body:
+      encoding: UTF-8
+      string: client_id=1125363250824366&client_secret=25b9c58e996fe09a1d4d2b243157b9f6&fb_exchange_token=CAAPZCgwzPBK4BADC6GXZCBntOEhqZCrwxacdjmfKxLdibgv9j8pKAMpnOQFswkAFJ2ZADUdjgZCviM8VpAnuChv200qXIEgiSMZCHNnX91cyDReuqmjX1mL7IJs0ULPfEhmZAT7ubDObADUFkoUZAtONzlf2ofMZAZA7aUdvnZAFmw4m7OqziAIypMBKU9LZCkxly6MZD&grant_type=fb_exchange_token
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/plain; charset=UTF-8
+      X-Fb-Trace-Id:
+      - DfubYKS5x1b
+      X-Fb-Rev:
+      - '1953636'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Facebook-Api-Version:
+      - v2.0
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      X-Fb-Debug:
+      - 6ym3XmzkS54n1+gMDlbsBGpTWeHHulttbAHRTxZjzfC45gohQ9t4GBrqksAI0A/Ev2nFsQfq/+a1rv3Leu7DfA==
+      Date:
+      - Thu, 24 Sep 2015 14:37:56 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '212'
+    body:
+      encoding: UTF-8
+      string: access_token=CAAPZCgwzPBK4BANZBHzVkwsonY2G40FbqPurfTdEFVbYeQs5Nj0dZAeAf3A9onpSZB5AxXncxz8btouSUZC6Qx6UXRVt2zninonPr9S7quHs4ONgKKBOkUB2OdqTHfZB3oSCpLX88OR3vffcgCHs1jNkHLqo5PPgBVgpeEO6d3EuOQ4Ri5Uc7T&expires=5183999
+    http_version: 
+  recorded_at: Thu, 24 Sep 2015 14:38:12 GMT
+- request:
+    method: get
+    uri: https://graph.facebook.com/oauth/client_code?access_token=CAAPZCgwzPBK4BANZBHzVkwsonY2G40FbqPurfTdEFVbYeQs5Nj0dZAeAf3A9onpSZB5AxXncxz8btouSUZC6Qx6UXRVt2zninonPr9S7quHs4ONgKKBOkUB2OdqTHfZB3oSCpLX88OR3vffcgCHs1jNkHLqo5PPgBVgpeEO6d3EuOQ4Ri5Uc7T&client_id=1125363250824366&client_secret=25b9c58e996fe09a1d4d2b243157b9f6&redirect_uri=http://localhost:4200/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Fb-Trace-Id:
+      - CzYcgH/ckHG
+      X-Fb-Rev:
+      - '1953636'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Facebook-Api-Version:
+      - v2.0
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      X-Fb-Debug:
+      - 1K8Weng+XvCYe8UxR+S9gxJF3yEDlociGytQdoy7ea54jqLZxpP6j/yO1IvXjIF7HWjlnRLzQiql6GaeP7sDJA==
+      Date:
+      - Thu, 24 Sep 2015 14:37:56 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '334'
+    body:
+      encoding: UTF-8
+      string: '{"code":"AQDMLHysjPovcMspFFLeOH8336Dztv_lSMq-y6VFSikuhvCmKeaxqU6CXlE84ptvA63nL9ZJKL_t3W-HjrtRKM9QGgdiuTzIcSaqM8p7H6ES-wukz-3h6zCMDUovMGT3r1skKTi6-3qGW9_fZmqtWnOlb_0Qzhy8eJIBv6wmj1m6-gJsYw9EV6qmaKd9c0h5U6lU85CKpcEYn3LZGgRVyfYtGYxgI-rli83yz1BSyKPOp_bC81HeRXXZK6St8SHZcdgXlbmkYkD_S2LBsf-ZRoNeyQ4ZPA4hJDHwJrzd9zAUwuF0fAwI_ukwzzrH5DATMGM"}'
+    http_version: 
+  recorded_at: Thu, 24 Sep 2015 14:38:13 GMT
+- request:
+    method: get
+    uri: https://graph.facebook.com/oauth/access_token?client_id=1125363250824366&client_secret=25b9c58e996fe09a1d4d2b243157b9f6&code=AQDMLHysjPovcMspFFLeOH8336Dztv_lSMq-y6VFSikuhvCmKeaxqU6CXlE84ptvA63nL9ZJKL_t3W-HjrtRKM9QGgdiuTzIcSaqM8p7H6ES-wukz-3h6zCMDUovMGT3r1skKTi6-3qGW9_fZmqtWnOlb_0Qzhy8eJIBv6wmj1m6-gJsYw9EV6qmaKd9c0h5U6lU85CKpcEYn3LZGgRVyfYtGYxgI-rli83yz1BSyKPOp_bC81HeRXXZK6St8SHZcdgXlbmkYkD_S2LBsf-ZRoNeyQ4ZPA4hJDHwJrzd9zAUwuF0fAwI_ukwzzrH5DATMGM&redirect_uri=http://localhost:4200/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Fb-Trace-Id:
+      - GOg/wrcS9V2
+      X-Fb-Rev:
+      - '1953636'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Facebook-Api-Version:
+      - v2.0
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      X-Fb-Debug:
+      - e1CChsiOZ2v4s8GfkOcqZ+6lFaG/+XpjW3o7tDyb8Jo5RPtTKMp3uyOZkzw6DjGdqlHsKGj7y5KVROYlYwIVkw==
+      Date:
+      - Thu, 24 Sep 2015 14:37:56 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '265'
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"CAAPZCgwzPBK4BAAlHMBbih6MJVpKnydbXUc4zn1ZCIaRqlD2QFrF9LCzuDYaWWmn4ASw6PSMz83Urj8DeZAvpDSiy7oqc5ZAsXO1mz6YBUfi1brc1KLCQ3BuLgFSYNtuLNGayNRZB4f1CCruPCGwMDjL9m7hoKJVdfuUtchXScuZC8RIZAnBd4ZC","machine_id":"xAoEVi37Hk4yUh-ovF-RLlUb","expires_in":5183999}'
+    http_version: 
+  recorded_at: Thu, 24 Sep 2015 14:38:13 GMT
+- request:
+    method: get
+    uri: https://graph.facebook.com/me?access_token=CAAPZCgwzPBK4BAAlHMBbih6MJVpKnydbXUc4zn1ZCIaRqlD2QFrF9LCzuDYaWWmn4ASw6PSMz83Urj8DeZAvpDSiy7oqc5ZAsXO1mz6YBUfi1brc1KLCQ3BuLgFSYNtuLNGayNRZB4f1CCruPCGwMDjL9m7hoKJVdfuUtchXScuZC8RIZAnBd4ZC&appsecret_proof=2ccc0ee7fadb804ba4585488a1a839790d3e09b53e0d85746033e7335ae74a1c&fields=email,%20name
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Fb-Trace-Id:
+      - G32MQsOAwV+
+      X-Fb-Rev:
+      - '1953636'
+      Etag:
+      - '"0191df1e12292610b85461502baa579d2205ca7c"'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Facebook-Api-Version:
+      - v2.4
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      X-Fb-Debug:
+      - 8zaM05ZwZl7dLkkT/ay2Jo9unugbd31pRtbLvyn22k3kMgo2Lh7SmUbnUQFGanntkT/oSX0FAqKbjBWOwK4csg==
+      Date:
+      - Thu, 24 Sep 2015 14:37:57 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '125'
+    body:
+      encoding: UTF-8
+      string: '{"email":"giabvhz_martinazzison_1443105472\u0040tfbnw.net","name":"Nancy
+        Alajbafhgehab Martinazzison","id":"138525189831376"}'
+    http_version: 
+  recorded_at: Thu, 24 Sep 2015 14:38:14 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
# Asana

https://app.asana.com/0/52390949460913/52390949460930
# Description

This PR adds Facebook authentication using Koala.

The process is similar to how it's done in cookacademy, except we are not using refresh tokens here (since it wasn't specified I ought to use them). Additionally, there has been an api change in facebook, so when retrieving a facebook user, we need to explicitly state we want their email.

An .env file is required to make this work, with the following 3 variables: 
- FACEBOOK_APP_ID
- FACEBOOK_APP_SECRET
- FACEBOOK_REDIRECT_URL

I'v been using a test app of my own with it, but my guess is, we want to create a proper facebook app as well as a test "sub-app" alongside it, to use in development and testing: https://developers.facebook.com/docs/apps/test-apps
