### PR TITLE
Added home_state column to users

### DIFF
--- a/db/migrate/20150925071113_add_home_state_to_users.rb
+++ b/db/migrate/20150925071113_add_home_state_to_users.rb
@@ -1,0 +1,5 @@
+class AddHomeStateToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :home_state, :string
+  end
+end

--- a/db/migrate/20150925071113_add_state_to_users.rb
+++ b/db/migrate/20150925071113_add_state_to_users.rb
@@ -1,5 +1,0 @@
-class AddStateToUsers < ActiveRecord::Migration
-  def change
-    add_column :users, :federal_state, :string
-  end
-end

--- a/db/migrate/20150925071113_add_state_to_users.rb
+++ b/db/migrate/20150925071113_add_state_to_users.rb
@@ -1,0 +1,5 @@
+class AddStateToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :federal_state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -65,7 +65,7 @@ ActiveRecord::Schema.define(version: 20150925071113) do
     t.string "remember_token",        limit: 128
     t.string "facebook_id"
     t.text   "facebook_access_token"
-    t.string "federal_state"
+    t.string "home_state"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150924131823) do
+ActiveRecord::Schema.define(version: 20150925071113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define(version: 20150924131823) do
     t.string "remember_token",        limit: 128
     t.string "facebook_id"
     t.text   "facebook_access_token"
+    t.string "federal_state"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", using: :btree

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -4,5 +4,6 @@ FactoryGirl.define do
     f.last_name "Doe"
     f.email "john-doe@mail.com"
     f.password "password"
+    f.federal_state "NY"
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,4 +12,16 @@ describe User do
   it "is invalid without a password" do
     expect(build(:user, password: nil)).not_to be_valid
   end
+
+  it "is valid without a federal_state" do
+    expect(build(:user, federal_state: nil)).to be_valid
+  end
+
+  it "is valid without a first_name" do
+    expect(build(:user, first_name: nil)).to be_valid
+  end
+
+  it "is valid without a last_name" do
+    expect(build(:user, last_name: nil)).to be_valid
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,4 +24,43 @@ describe User do
   it "is valid without a last_name" do
     expect(build(:user, last_name: nil)).to be_valid
   end
+
+  it "can have followers" do
+    user = create(:user)
+    other_user_1 = create(:user)
+    other_user_2 = create(:user)
+    create(:relationship, follower: other_user_1, followed: user)
+    create(:relationship, follower: other_user_2, followed: user)
+
+    expect(user.followers.length).to eq 2
+  end
+
+  it "can have other users it follows" do
+    user = create(:user)
+    other_user_1 = create(:user)
+    other_user_2 = create(:user)
+    create(:relationship, follower: user, followed: other_user_1)
+    create(:relationship, follower: user, followed: other_user_2)
+
+    expect(user.following.length).to eq 2
+  end
+
+  it "can follow another user" do
+    user = create(:user)
+    other_user = create(:user)
+
+    user.follow(other_user)
+    expect(user.following? other_user).to be true
+  end
+
+  it "can unfollow another user" do
+    user = create(:user)
+    other_user = create(:user)
+    create(:relationship, follower: user, followed: other_user)
+
+    expect(user.following? other_user).to be true
+
+    user.unfollow(other_user)
+    expect(user.following? other_user).to be false
+  end
 end

--- a/spec/requests/api/tokens_spec.rb
+++ b/spec/requests/api/tokens_spec.rb
@@ -53,6 +53,10 @@ describe "Tokens API" do
         @facebook_auth_code = oauth.generate_client_code(long_lived_token_info["access_token"])
       end
 
+      after do
+        AddFacebookFriendsWorker.drain
+      end
+
       context "when the user does not already exist" do
 
         it 'creates a user from Facebook and returns a token', vcr: { cassette_name: 'requests/api/tokens/creates a user' } do
@@ -67,7 +71,6 @@ describe "Tokens API" do
           expect(json.token_type).to eq "bearer"
 
           expect(AddFacebookFriendsWorker.jobs.size).to eq 1
-          AddFacebookFriendsWorker.drain
         end
 
       end


### PR DESCRIPTION
- [Asana: Add state to users (i.e. one of the 50 US states)](https://app.asana.com/0/52390949460913/52390949460951)
# Description

This PR adds a column named `federal_state` to users, as well as tests to the user model to make sure the column is nullable. 

That being said, I'm not sure if this is what we want.
## Questions
- [x] Is `federal_state` ok? I didn't want to make it just `state`, since that name isn't exactly the clearest and could have other meanings. - *\*  `home_state` will is the name we opted for**
- [x] Do we actually want the state, or just the state code? - **the state code**
- [x] Should it be nullable? I'm guessing yes, since I don't think we can fetch it automatically when the user is registering through Facebook. - **yes, nullable**

Depending on the answers, this could be mergeable.
