### PR TITLE
Add missing specs

### DIFF
--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -46,7 +46,7 @@ describe Address do
     expect(address.asked_to_leave?).to be true
   end
 
-  context ".new_or_existing_from_params" do
+  describe ".new_or_existing_from_params" do
     it "initializes a new address if the params do not contain an id", vcr: { cassette_name: "models/address/creates_a_new_address_if_the_params_do_not_contain_an_id" } do
       expect(Address.count).to eq 0
       params = {

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -45,4 +45,29 @@ describe Address do
     address.asked_to_leave!
     expect(address.asked_to_leave?).to be true
   end
+
+  context ".new_or_existing_from_params" do
+    it "initializes a new address if the params do not contain an id", vcr: { cassette_name: "models/address/creates_a_new_address_if_the_params_do_not_contain_an_id" } do
+      expect(Address.count).to eq 0
+      params = {
+        latitude: 1,
+        longitude: 1
+      }
+      address = Address.new_or_existing_from_params(params)
+      expect(address.persisted?).to be false
+    end
+    it "fetches and updates (without save) an existing address if the params do contain an id" do
+      create(:address, id: 1, latitude: 0, longitude: 0)
+      params = {
+        id: 1,
+        latitude: 1,
+        longitude: 1
+      }
+      address = Address.new_or_existing_from_params(params)
+      expect(Address.count).to eq 1
+      expect(address.changed?).to be true
+      expect(address.latitude).to eq 1
+      expect(address.longitude).to eq 1
+    end
+  end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -46,6 +46,18 @@ describe Address do
     expect(address.asked_to_leave?).to be true
   end
 
+  describe "#assign_most_supportive_resident" do
+    it "assigns person as most supportive resident and persons canvas_response as best_canvas_response" do
+      address = create(:address)
+      person = create(:person, canvas_response: :strongly_for)
+
+      address.assign_most_supportive_resident(person)
+
+      expect(address.most_supportive_resident).to eq person
+      expect(address.best_canvas_response).to eq person.canvas_response
+    end
+  end
+
   describe ".new_or_existing_from_params" do
     it "initializes a new address if the params do not contain an id", vcr: { cassette_name: "models/address/creates_a_new_address_if_the_params_do_not_contain_an_id" } do
       expect(Address.count).to eq 0

--- a/spec/models/address_update_spec.rb
+++ b/spec/models/address_update_spec.rb
@@ -25,7 +25,7 @@ describe AddressUpdate do
     expect(address_update.created?).to be true
   end
 
-  context "#create_for_visit_and_address" do
+  context ".create_for_visit_and_address" do
     it "creates an update with 'created' type if address is a new record" do
       visit = create(:visit)
       address = build(:address)

--- a/spec/models/address_update_spec.rb
+++ b/spec/models/address_update_spec.rb
@@ -25,7 +25,7 @@ describe AddressUpdate do
     expect(address_update.created?).to be true
   end
 
-  context ".create_for_visit_and_address" do
+  describe ".create_for_visit_and_address" do
     it "creates an update with 'created' type if address is a new record" do
       visit = create(:visit)
       address = build(:address)

--- a/spec/models/address_update_spec.rb
+++ b/spec/models/address_update_spec.rb
@@ -24,4 +24,20 @@ describe AddressUpdate do
     address_update.created!
     expect(address_update.created?).to be true
   end
+
+  context "#create_for_visit_and_address" do
+    it "creates an update with 'created' type if address is a new record" do
+      visit = create(:visit)
+      address = build(:address)
+      address_update = AddressUpdate.create_for_visit_and_address(visit, address)
+      expect(address_update.created?).to be true
+    end
+
+    it "creates an update with 'modified' type if address is an existing record" do
+      visit = create(:visit)
+      address = create(:address)
+      address_update = AddressUpdate.create_for_visit_and_address(visit, address)
+      expect(address_update.modified?).to be true
+    end
+  end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -75,4 +75,29 @@ describe Person do
       expect(person.canvas_response_rating).to eq -1
     end
   end
+
+  describe ".new_or_existing_from_params" do
+    it "initializes a new person if the params do not contain an id" do
+      expect(Person.count).to eq 0
+      params = {
+        first_name: "John",
+        last_name: "Doe"
+      }
+      person = Person.new_or_existing_from_params(params)
+      expect(person.persisted?).to be false
+    end
+    it "fetches and updates (without save) an existing person if the params do contain an id" do
+      create(:person, id: 1, first_name: "Jake", last_name: "Smith")
+      params = {
+        id: 1,
+        first_name: "John",
+        last_name: "Doe"
+      }
+      person = Person.new_or_existing_from_params(params)
+      expect(Person.count).to eq 1
+      expect(person.changed?).to be true
+      expect(person.first_name).to eq "John"
+      expect(person.last_name).to eq "Doe"
+    end
+  end
 end

--- a/spec/models/person_update_spec.rb
+++ b/spec/models/person_update_spec.rb
@@ -39,7 +39,7 @@ describe PersonUpdate do
     expect(person_update.created?).to be true
   end
 
-  context "#create_for_visit_and_person" do
+  context ".create_for_visit_and_person" do
     it "creates an update with 'created' type if person is a new record" do
       visit = create(:visit)
       person = build(:person)

--- a/spec/models/person_update_spec.rb
+++ b/spec/models/person_update_spec.rb
@@ -39,7 +39,7 @@ describe PersonUpdate do
     expect(person_update.created?).to be true
   end
 
-  context ".create_for_visit_and_person" do
+  describe ".create_for_visit_and_person" do
     it "creates an update with 'created' type if person is a new record" do
       visit = create(:visit)
       person = build(:person)

--- a/spec/models/person_update_spec.rb
+++ b/spec/models/person_update_spec.rb
@@ -38,4 +38,20 @@ describe PersonUpdate do
     person_update.created!
     expect(person_update.created?).to be true
   end
+
+  context "#create_for_visit_and_person" do
+    it "creates an update with 'created' type if person is a new record" do
+      visit = create(:visit)
+      person = build(:person)
+      person_update = PersonUpdate.create_for_visit_and_person(visit, person)
+      expect(person_update.created?).to be true
+    end
+
+    it "creates an update with 'modified' type if person is an existing record" do
+      visit = create(:visit)
+      person = create(:person)
+      person_update = PersonUpdate.create_for_visit_and_person(visit, person)
+      expect(person_update.modified?).to be true
+    end
+  end
 end

--- a/spec/vcr/models/address/creates_a_new_address_if_the_params_do_not_contain_an_id.yml
+++ b/spec/vcr/models/address/creates_a_new_address_if_the_params_do_not_contain_an_id.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses/create_and_verify
+    body:
+      encoding: US-ASCII
+      string: address[street1]=
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.1.7
+      Authorization:
+      - Bearer EASYPOST_API_KEY
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '17'
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Thu, 22 Oct 2015 07:52:22 GMT
+      Status:
+      - 400 Bad Request
+      Connection:
+      - close
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 891f5861-8e2f-4b1a-932c-8bc1d467fcbd
+      X-Runtime:
+      - '0.535332'
+      X-Node:
+      - web3sj, f19e35272a
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb5sj, d36de79499
+      Strict-Transport-Security:
+      - max-age=86400
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"ADDRESS.VERIFY.FAILURE","message":"Insufficient address
+        data provided. A street must be provided.","errors":[]}}'
+    http_version: 
+  recorded_at: Thu, 22 Oct 2015 07:52:25 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
There's no Asana task for this, but looking at the code, I realised we probably should be testing these things.

This PR adds specs for
- `Person.new_or_existing_from_params`
- `Address.new_or_existing_from_params`
- `PersonUpdate.create_for_visit_and_person`
- `AddressUpdate.create_for_visit_and_address`
- `Address#assign_most_supportive_resident`
