### PR TITLE
Spec/automatic leader board update on post patch user

### DIFF
--- a/lib/ground_game/scenario/update_leaderboards.rb
+++ b/lib/ground_game/scenario/update_leaderboards.rb
@@ -8,7 +8,7 @@ module GroundGame
       def call
         everyone_leaderboard.rank_user(@user)
         friends_leaderboard.rank_user(@user)
-        state_leaderboard.rank_user(@user)
+        state_leaderboard.rank_user(@user) if @user.state_code
       end
 
       private

--- a/lib/ground_game/scenario/update_member_data_in_leaderboards.rb
+++ b/lib/ground_game/scenario/update_member_data_in_leaderboards.rb
@@ -8,7 +8,7 @@ module GroundGame
       def call
         everyone_leaderboard.rank_user(@user)
         friends_leaderboard.rank_user(@user)
-        state_leaderboard.rank_user(@user)
+        state_leaderboard.rank_user(@user) if @user.state_code
       end
 
       private

--- a/spec/lib/ground_game/scenario/update_leaderboards_spec.rb
+++ b/spec/lib/ground_game/scenario/update_leaderboards_spec.rb
@@ -7,41 +7,54 @@ module GroundGame
     describe UpdateLeaderboards do
 
       describe "#call" do
+        context "when the user has all the required information" do
 
-        before do
-          @user = create(:user, id: 10, email: "test-user@mail.com", password: "password", state_code: "NY")
+          before do
+            @user = create(:user, id: 10, email: "test-user@mail.com", password: "password", state_code: "NY")
 
-          # I would love to somehow have this work with factory_girl or something similar, but I'm not sure how
+            # I would love to somehow have this work with factory_girl or something similar, but I'm not sure how
 
-          everyone = UserLeaderboard.for_everyone
-          3.times { |n| everyone.rank_member(n.to_s, n) }
+            everyone = UserLeaderboard.for_everyone
+            3.times { |n| everyone.rank_member(n.to_s, n) }
 
-          state_ny = UserLeaderboard.for_state("NY")
-          2.times { |n| state_ny.rank_member(n.to_s, n) }
+            state_ny = UserLeaderboard.for_state("NY")
+            2.times { |n| state_ny.rank_member(n.to_s, n) }
 
-          friends = UserLeaderboard.for_friend_list_of_user(@user)
-          5.times { |n| friends.rank_member(n.to_s, n) }
+            friends = UserLeaderboard.for_friend_list_of_user(@user)
+            5.times { |n| friends.rank_member(n.to_s, n) }
+          end
+
+          it "updates the 'everyone' leaderboard" do
+            UpdateLeaderboards.new(@user).call
+
+            everyone_rankings = Ranking.for_everyone(id: 10)
+            expect(everyone_rankings.length).to eq 4
+          end
+
+          it "updates the user's 'state' leaderboard" do
+            UpdateLeaderboards.new(@user).call
+
+            ny_rankings = Ranking.for_state(id: 10, state_code: "NY")
+            expect(ny_rankings.length).to eq 3
+          end
+
+          it "updates the user's 'friends' leaderboard" do
+            UpdateLeaderboards.new(@user).call
+
+            friend_rankings = Ranking.for_user_in_users_friend_list(user: @user)
+            expect(friend_rankings.length).to eq 6
+          end
         end
 
-        it "updates the 'everyone' leaderboard" do
-          UpdateLeaderboards.new(@user).call
+        context "when the user doesn't have a state code" do
+          before do
+            @user_without_state = create(:user, id: 11, email: "test-user@mail.com", password: "password", state_code: nil)
+          end
 
-          everyone_rankings = Ranking.for_everyone(id: 10)
-          expect(everyone_rankings.length).to eq 4
-        end
-
-        it "updates the user's 'state' leaderboard" do
-          UpdateLeaderboards.new(@user).call
-
-          ny_rankings = Ranking.for_state(id: 10, state_code: "NY")
-          expect(ny_rankings.length).to eq 3
-        end
-
-        it "updates the user's 'friends' leaderboard" do
-          UpdateLeaderboards.new(@user).call
-
-          friend_rankings = Ranking.for_user_in_users_friend_list(user: @user)
-          expect(friend_rankings.length).to eq 6
+          it "should not update any 'state' leaderboard" do
+            expect(UserLeaderboard).not_to receive(:for_state)
+            UpdateLeaderboards.new(@user_without_state).call
+          end
         end
       end
     end

--- a/spec/lib/ground_game/scenario/update_member_data_in_leaderboards_spec.rb
+++ b/spec/lib/ground_game/scenario/update_member_data_in_leaderboards_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+require "ground_game/scenario/update_member_data_in_leaderboards"
+
+module GroundGame
+  module Scenario
+
+    describe UpdateMemberDataInLeaderboards do
+
+      describe "#call" do
+
+        context "when the user has all the required information" do
+          before do
+            @user = create(:user, id: 10, email: "test-user@mail.com", password: "password", state_code: "NY")
+
+            # I would love to somehow have this work with factory_girl or something similar, but I'm not sure how
+
+            everyone = UserLeaderboard.for_everyone
+            3.times { |n| everyone.rank_member(n.to_s, n) }
+
+            state_ny = UserLeaderboard.for_state("NY")
+            2.times { |n| state_ny.rank_member(n.to_s, n) }
+
+            friends = UserLeaderboard.for_friend_list_of_user(@user)
+            5.times { |n| friends.rank_member(n.to_s, n) }
+          end
+
+          it "updates the 'everyone' leaderboard" do
+            UpdateMemberDataInLeaderboards.new(@user).call
+
+            everyone_rankings = Ranking.for_everyone(id: 10)
+            expect(everyone_rankings.length).to eq 4
+          end
+
+          it "updates the user's 'state' leaderboard" do
+            UpdateMemberDataInLeaderboards.new(@user).call
+
+            ny_rankings = Ranking.for_state(id: 10, state_code: "NY")
+            expect(ny_rankings.length).to eq 3
+          end
+
+          it "updates the user's 'friends' leaderboard" do
+            UpdateMemberDataInLeaderboards.new(@user).call
+
+            friend_rankings = Ranking.for_user_in_users_friend_list(user: @user)
+            expect(friend_rankings.length).to eq 6
+          end
+        end
+
+        context "when the user doesn't have a state code" do
+          before do
+            @user_without_state = create(:user, id: 11, email: "test-user@mail.com", password: "password", state_code: nil)
+          end
+
+          it "should not update any 'state' leaderboard" do
+            expect(UserLeaderboard).not_to receive(:for_state)
+            UpdateMemberDataInLeaderboards.new(@user_without_state).call
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -61,55 +61,6 @@ describe "Users API" do
       end
     end
 
-    describe "automatic leaderboard update" do
-      before do
-        file = File.open("#{Rails.root}/spec/sample_data/default-avatar.png", 'r')
-        base_64_image = Base64.encode64(open(file) { |io| io.read })
-        @user_attributes = {
-          data: {
-            attributes: {
-              email: email,
-              password: password,
-              first_name: first_name,
-              last_name: last_name,
-              state_code: "NY",
-              base_64_photo_data: base_64_image
-            }
-          }
-        }
-      end
-
-      it "should update the 'everyone' leaderboard" do
-        Sidekiq::Testing.inline! do
-          post "#{host}/users", @user_attributes
-
-          rankings = Ranking.for_everyone(id: User.last.id)
-          expect(rankings.length).to eq 1
-          expect(rankings.first[:member]).to eq User.last.id.to_s
-        end
-      end
-
-      it "should update the 'state' leaderboard" do
-        Sidekiq::Testing.inline! do
-          post "#{host}/users", @user_attributes
-
-          rankings = Ranking.for_state(id: User.last.id, state_code: "NY")
-          expect(rankings.length).to eq 1
-          expect(rankings.first[:member]).to eq User.last.id.to_s
-        end
-      end
-
-      it "should update the 'friends' leaderboard" do
-        Sidekiq::Testing.inline! do
-          post "#{host}/users", @user_attributes
-
-          rankings = Ranking.for_user_in_users_friend_list(user: User.last)
-          expect(rankings.length).to eq 1
-          expect(rankings.first[:member]).to eq User.last.id.to_s
-        end
-      end
-    end
-
     context "with invalid data" do
 
       it "fails on a blank password" do
@@ -142,6 +93,95 @@ describe "Users API" do
         expect(last_response.status).to eq 422
 
         expect(json.errors.email).to eq "has already been taken"
+      end
+    end
+
+    describe "automatic leaderboard update" do
+
+      context "when the user is being created with a photo" do
+        before do
+          file = File.open("#{Rails.root}/spec/sample_data/default-avatar.png", 'r')
+          base_64_image = Base64.encode64(open(file) { |io| io.read })
+          @user_attributes = {
+            data: {
+              attributes: {
+                email: email,
+                password: password,
+                first_name: first_name,
+                last_name: last_name,
+                state_code: "NY",
+                base_64_photo_data: base_64_image
+              }
+            }
+          }
+        end
+
+        it "should update the 'everyone' leaderboard" do
+          Sidekiq::Testing.inline! do
+            post "#{host}/users", @user_attributes
+
+            rankings = Ranking.for_everyone(id: User.last.id)
+            expect(rankings.length).to eq 1
+            expect(rankings.first[:member]).to eq User.last.id.to_s
+          end
+        end
+
+        it "should update the 'state' leaderboard" do
+          Sidekiq::Testing.inline! do
+            post "#{host}/users", @user_attributes
+
+            rankings = Ranking.for_state(id: User.last.id, state_code: "NY")
+            expect(rankings.length).to eq 1
+            expect(rankings.first[:member]).to eq User.last.id.to_s
+          end
+        end
+
+        it "should update the 'friends' leaderboard" do
+          Sidekiq::Testing.inline! do
+            post "#{host}/users", @user_attributes
+
+            rankings = Ranking.for_user_in_users_friend_list(user: User.last)
+            expect(rankings.length).to eq 1
+            expect(rankings.first[:member]).to eq User.last.id.to_s
+          end
+        end
+      end
+
+      context "when the user is being created without a photo" do
+        before do
+          @user_attributes = {
+            data: {
+              attributes: {
+                email: email,
+                password: password,
+                first_name: first_name,
+                last_name: last_name,
+                state_code: "NY"
+              }
+            }
+          }
+        end
+
+        it "should not update the 'everyone' leaderboard" do
+          Sidekiq::Testing.inline! do
+            expect(UserLeaderboard).not_to receive(:for_everyone)
+            post "#{host}/users", @user_attributes
+          end
+        end
+
+        it "should not update the 'state' leaderboard" do
+          Sidekiq::Testing.inline! do
+            expect(UserLeaderboard).not_to receive(:for_state)
+            post "#{host}/users", @user_attributes
+          end
+        end
+
+        it "should not update the 'friends' leaderboard" do
+          Sidekiq::Testing.inline! do
+            expect(UserLeaderboard).not_to receive(:for_friend_list_of_user)
+            post "#{host}/users", @user_attributes
+          end
+        end
       end
     end
 
@@ -199,51 +239,73 @@ describe "Users API" do
     end
 
     describe "automatic leaderboard update" do
-      before do
-        file = File.open("#{Rails.root}/spec/sample_data/default-avatar.png", 'r')
-        base_64_image = Base64.encode64(open(file) { |io| io.read })
-        @user_attributes = {
-          data: {
-            attributes: {
-              email: "new@mail.com",
-              base_64_photo_data: base_64_image
-            }
-          }
-        }
-      end
 
-      it "should update the 'everyone' leaderboard" do
-        Sidekiq::Testing.inline! do
-          authenticated_post "users/me", @user_attributes, token
+      context "when the user is having their photo updated" do
+        before do
+          file = File.open("#{Rails.root}/spec/sample_data/default-avatar.png", 'r')
+          base_64_image = Base64.encode64(open(file) { |io| io.read })
+          @user_attributes = { data: { attributes: { email: "new@mail.com", base_64_photo_data: base_64_image } } }
+        end
 
-          rankings = Ranking.for_everyone(id: User.last.id)
-          expect(rankings.length).to eq 1
-          expect(rankings.first[:member]).to eq User.last.id.to_s
+        it "should update the 'everyone' leaderboard" do
+          Sidekiq::Testing.inline! do
+            authenticated_post "users/me", @user_attributes, token
+
+            rankings = Ranking.for_everyone(id: User.last.id)
+            expect(rankings.length).to eq 1
+            expect(rankings.first[:member]).to eq User.last.id.to_s
+          end
+        end
+
+        it "should update the 'state' leaderboard" do
+          Sidekiq::Testing.inline! do
+            authenticated_post "users/me", @user_attributes, token
+
+            rankings = Ranking.for_state(id: User.last.id, state_code: "NY")
+            expect(rankings.length).to eq 1
+            expect(rankings.first[:member]).to eq User.last.id.to_s
+          end
+        end
+
+        it "should update the 'friends' leaderboard" do
+          Sidekiq::Testing.inline! do
+            authenticated_post "users/me", @user_attributes, token
+
+            rankings = Ranking.for_user_in_users_friend_list(user: User.last)
+            expect(rankings.length).to eq 1
+            expect(rankings.first[:member]).to eq User.last.id.to_s
+          end
         end
       end
 
-      it "should update the 'state' leaderboard" do
-        Sidekiq::Testing.inline! do
-          authenticated_post "users/me", @user_attributes, token
-
-          rankings = Ranking.for_state(id: User.last.id, state_code: "NY")
-          expect(rankings.length).to eq 1
-          expect(rankings.first[:member]).to eq User.last.id.to_s
+      context "when the user is not having their photo updated" do
+        before do
+          @token = token  # need to evaluate token ahead of time
+          @user_attributes = { data: { attributes: { email: "new@mail.com" } } }
         end
-      end
 
-      it "should update the 'friends' leaderboard" do
-        Sidekiq::Testing.inline! do
-          authenticated_post "users/me", @user_attributes, token
+        it "should not update the 'everyone' leaderboard" do
+          Sidekiq::Testing.inline! do
+            expect(UserLeaderboard).not_to receive(:for_everyone)
+            authenticated_post "users/me", @user_attributes, @token
+          end
+        end
 
-          rankings = Ranking.for_user_in_users_friend_list(user: User.last)
-          expect(rankings.length).to eq 1
-          expect(rankings.first[:member]).to eq User.last.id.to_s
+        it "should not update the 'state' leaderboard" do
+          Sidekiq::Testing.inline! do
+            expect(UserLeaderboard).not_to receive(:for_state)
+            authenticated_post "users/me", @user_attributes, @token
+          end
+        end
+
+        it "should not update the 'friends' leaderboard" do
+          Sidekiq::Testing.inline! do
+            expect(UserLeaderboard).not_to receive(:for_friend_list_of_user)
+            authenticated_post "users/me", @user_attributes, @token
+          end
         end
       end
     end
-
-
   end
 
   context 'GET users/me' do

--- a/spec/workers/update_profile_picture_worker_spec.rb
+++ b/spec/workers/update_profile_picture_worker_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe UpdateProfilePictureWorker do
+
+  before do
+  end
+
+  context "when the user has 'base_64_photo_data'" do
+    before do
+      file = File.open("#{Rails.root}/spec/sample_data/default-avatar.png", 'r')
+      base_64_image = Base64.encode64(open(file) { |io| io.read })
+      @user = create(:user, base_64_photo_data: base_64_image)
+    end
+
+    it "updates leaderboards" do
+      expect_any_instance_of(GroundGame::Scenario::UpdateMemberDataInLeaderboards).to receive(:call)
+      UpdateProfilePictureWorker.new.perform(@user.id)
+    end
+  end
+
+  context "when the user does not have 'base_64_photo_data'" do
+    before do
+      @user = create(:user)
+    end
+    it "does not update leaderboards" do
+      expect_any_instance_of(GroundGame::Scenario::UpdateMemberDataInLeaderboards).not_to receive(:call)
+      UpdateProfilePictureWorker.new.perform(@user.id)
+    end
+  end
+end


### PR DESCRIPTION
- [Asana task: Add spec for updating member data in leaderboards on profile picture change](https://app.asana.com/0/60127409159606/60649398425927)
# Description

This PR adds the following specs
1. Check 'everyone', 'state' and 'friends' leaderboards are updated to user POST and PATCH specs in `spec/requests/api/user`, when the user has picture data, and not updated when the user does not have picture data.
2. Specs for `UpdateProfilePictureWorker` to ensure the worker only executes the proper scenario (`UpdateMemberDataInLeaderboards`) when there is picture data.
3. Specs for `UpdateMemberDataInLeaderboards` scenario, which also checks that the scenario updates the 'everyone', 'state', and 'friends' leaderboards.
4. Spec for edge case when user doesn't have a state code asigned to `UpdateMemberDataInLeaderboards` scenario. We didn't outright define the behavior here, so my assumption is that **no state leaderboard should be updated in that case**.

Additionally, due to the edge case missing and the `UpdateLeaderboards` and `UpdateMemberDataInLeaderboards` scenarios being identical**, I added the same edge case spec to the `UpdateLeaderboards` scenario. 
