### PR TITLE
Modified 'AddFacebookProfilePicture' worker to only do the work if the user doesn't have a photo already

### DIFF
--- a/app/workers/add_facebook_profile_picture.rb
+++ b/app/workers/add_facebook_profile_picture.rb
@@ -3,12 +3,21 @@ class AddFacebookProfilePicture
 
   def perform(user_id)
     user = User.find(user_id)
-    facebook_access_token = user.facebook_access_token
-    graph = Koala::Facebook::API.new(facebook_access_token, ENV['FACEBOOK_APP_SECRET'])
-    picture = graph.get_object('me?fields=picture')
-    picture_url = picture['picture'].try(:[], 'data').try(:[], 'url')
-    return unless picture_url
-    user.photo = URI.parse(picture_url)
-    user.save
+
+    photo_url = facebook_photo_url(user) unless user.photo.path
+
+    if photo_url
+      user.photo = URI.parse(photo_url)
+      user.save
+    end
   end
+
+  private
+    def facebook_photo_url(user)
+      facebook_access_token = user.facebook_access_token
+      graph = Koala::Facebook::API.new(facebook_access_token, ENV['FACEBOOK_APP_SECRET'])
+      picture = graph.get_object('me?fields=picture')
+      picture_url = picture['picture'].try(:[], 'data').try(:[], 'url')
+      picture_url
+    end
 end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -6,5 +6,14 @@ FactoryGirl.define do
     f.home_state "NY"
 
     sequence(:email) { |n| "user_" + n.to_s + "@mail.com" }
+
+    trait :with_a_photo do
+      after(:build) do |user, evaluator|
+        file = File.open("#{Rails.root}/spec/sample_data/default-avatar.png", 'r')
+        base_64_image = Base64.encode64(open(file) { |io| io.read })
+        user.base_64_photo_data = base_64_image
+        user.decode_image_data
+      end
+    end
   end
 end

--- a/spec/workers/add_facebook_profile_picture_spec.rb
+++ b/spec/workers/add_facebook_profile_picture_spec.rb
@@ -1,17 +1,35 @@
 require 'rails_helper'
 
-describe AddFacebookProfilePicture do
+describe AddFacebookProfilePicture ,vcr: { cassette_name: 'workers/add profile pic/add_profile_pic_from_facebook' } do
 
   before do
     oauth = Koala::Facebook::OAuth.new(ENV["FACEBOOK_APP_ID"], ENV["FACEBOOK_APP_SECRET"], ENV["FACEBOOK_REDIRECT_URL"])
     test_users = Koala::Facebook::TestUsers.new(app_id: ENV["FACEBOOK_APP_ID"], secret: ENV["FACEBOOK_APP_SECRET"])
-    facebook_user = test_users.create(true, "email,user_friends")
-    @user = create(:user, facebook_id: facebook_user["id"], facebook_access_token: facebook_user["access_token"])
+    @facebook_user = test_users.create(true, "email,user_friends")
   end
 
-  it 'adds a profile picture from facebook', vcr: { cassette_name: 'workers/add profile pic/add_profile_pic_from_facebook' } do
-    AddFacebookProfilePicture.new.perform(@user.id)
-    @user.reload
-    expect(@user.photo.path).to_not be_nil
+  context "when user already has a photo" do
+    before do
+      @user = create(:user, :with_a_photo, facebook_id: @facebook_user["id"], facebook_access_token: @facebook_user["access_token"])
+    end
+
+    it "doesn't modify the photo" do
+      AddFacebookProfilePicture.new.perform(@user.id)
+      @user.reload
+      expect(@user.photo.path).to include "original.png"
+    end
+  end
+
+  context "when user doesn't have a photo" do
+    before do
+      @user = create(:user, facebook_id: @facebook_user["id"], facebook_access_token: @facebook_user["access_token"])
+    end
+
+    it "adds a profile picture from facebook" do
+      AddFacebookProfilePicture.new.perform(@user.id)
+      @user.reload
+      expect(@user.photo.path).not_to be_nil
+      expect(@user.photo.path).not_to include "original.png"
+    end
   end
 end


### PR DESCRIPTION
- [Asana task: Don't re-add facebook profile picture every time they log in](https://app.asana.com/0/60127409159606/60649398425938)
# Description

As the title says, this commit changes the worker so the user photo is set from facebook only if the user doesn't have a photo already.

However, I'm **not completely sure if this is the behavior we want**. We may want to update the photo anyway if the previous photo was also a facebook photo. We could do this by checking if the current `photo.data.url` contains something like `'fbcdn-profile'`.

If the current behavior is how we want it, then this is mergeable. Otherwise, I can make the changes.
