### PR TITLE
update leaderboards on user create and update with or without photo

### DIFF
--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -32,7 +32,6 @@ class TokensController < Doorkeeper::TokensController
       u = GroundGame::Scenario::UpdateUserAttributesFromFacebook.new(u, facebook_user).call
       u.facebook_access_token = facebook_access_token
       u.password = User.friendly_token unless u.encrypted_password.present?
-
       u.save!
     end
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -162,24 +162,33 @@ describe "Users API" do
           }
         end
 
-        it "should not update the 'everyone' leaderboard" do
+        it "should update the 'everyone' leaderboard" do
           Sidekiq::Testing.inline! do
-            expect(UserLeaderboard).not_to receive(:for_everyone)
             post "#{host}/users", @user_attributes
+
+            rankings = Ranking.for_everyone(id: User.last.id)
+            expect(rankings.length).to eq 1
+            expect(rankings.first[:member]).to eq User.last.id.to_s
           end
         end
 
-        it "should not update the 'state' leaderboard" do
+        it "should update the 'state' leaderboard" do
           Sidekiq::Testing.inline! do
-            expect(UserLeaderboard).not_to receive(:for_state)
             post "#{host}/users", @user_attributes
+
+            rankings = Ranking.for_state(id: User.last.id, state_code: "NY")
+            expect(rankings.length).to eq 1
+            expect(rankings.first[:member]).to eq User.last.id.to_s
           end
         end
 
-        it "should not update the 'friends' leaderboard" do
+        it "should update the 'friends' leaderboard" do
           Sidekiq::Testing.inline! do
-            expect(UserLeaderboard).not_to receive(:for_friend_list_of_user)
             post "#{host}/users", @user_attributes
+
+            rankings = Ranking.for_user_in_users_friend_list(user: User.last)
+            expect(rankings.length).to eq 1
+            expect(rankings.first[:member]).to eq User.last.id.to_s
           end
         end
       end
@@ -284,24 +293,33 @@ describe "Users API" do
           @user_attributes = { data: { attributes: { email: "new@mail.com" } } }
         end
 
-        it "should not update the 'everyone' leaderboard" do
+        it "should update the 'everyone' leaderboard" do
           Sidekiq::Testing.inline! do
-            expect(UserLeaderboard).not_to receive(:for_everyone)
-            authenticated_post "users/me", @user_attributes, @token
+            authenticated_post "users/me", @user_attributes, token
+
+            rankings = Ranking.for_everyone(id: User.last.id)
+            expect(rankings.length).to eq 1
+            expect(rankings.first[:member]).to eq User.last.id.to_s
           end
         end
 
-        it "should not update the 'state' leaderboard" do
+        it "should update the 'state' leaderboard" do
           Sidekiq::Testing.inline! do
-            expect(UserLeaderboard).not_to receive(:for_state)
-            authenticated_post "users/me", @user_attributes, @token
+            authenticated_post "users/me", @user_attributes, token
+
+            rankings = Ranking.for_state(id: User.last.id, state_code: "NY")
+            expect(rankings.length).to eq 1
+            expect(rankings.first[:member]).to eq User.last.id.to_s
           end
         end
 
-        it "should not update the 'friends' leaderboard" do
+        it "should update the 'friends' leaderboard" do
           Sidekiq::Testing.inline! do
-            expect(UserLeaderboard).not_to receive(:for_friend_list_of_user)
-            authenticated_post "users/me", @user_attributes, @token
+            authenticated_post "users/me", @user_attributes, token
+
+            rankings = Ranking.for_user_in_users_friend_list(user: User.last)
+            expect(rankings.length).to eq 1
+            expect(rankings.first[:member]).to eq User.last.id.to_s
           end
         end
       end

--- a/spec/workers/update_profile_picture_worker_spec.rb
+++ b/spec/workers/update_profile_picture_worker_spec.rb
@@ -29,11 +29,6 @@ describe UpdateProfilePictureWorker do
       @user = create(:user)
     end
 
-    it "does not update leaderboards" do
-      expect_any_instance_of(GroundGame::Scenario::UpdateMemberDataInLeaderboards).not_to receive(:call)
-      UpdateProfilePictureWorker.new.perform(@user.id)
-    end
-
     it "doesn't touch photo" do
       UpdateProfilePictureWorker.new.perform(@user.id)
 


### PR DESCRIPTION
NB: There is a tiny bit of inefficiency here when there is a profile pic in that the leaderboard will be updated twice (once from the UpdateUsersLeaderboardsWorker and once from the UpdateProfilePictureWorker). However, given that this is happening in asynchronous background jobs, it may even be desirable behavior (ie; user info will be updated for other users even before the profile pic is ready and then when the profile pic is ready it will be updated for other users as well)

The alternative is that the asynchronous call to the UpdateUsersLeaderboardsWorker finishes before the profile picture worker and it updates the leaderboard with the incorrect info.

What do you think?
