### PR TITLE
Feature: Error responses for visit creation in JSON API format

### DIFF
--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -9,7 +9,7 @@ class VisitsController < ApplicationController
       UpdateUsersLeaderboardsWorker.perform_async(result[:visit].user.id)
       render json: result[:visit], include: ['score']
     else
-      # TODO: Error
+      render json: result[:error], status: result[:error][:errors][:status]
     end
   end
 

--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -5,11 +5,11 @@ class VisitsController < ApplicationController
 
   def create
     result = GroundGame::Scenario::CreateVisit.new(visit_params, address, people, current_user).call
-    if result[:success] == true
-      UpdateUsersLeaderboardsWorker.perform_async(result[:visit].user.id)
-      render json: result[:visit], include: ['score']
+    if result.success?
+      UpdateUsersLeaderboardsWorker.perform_async(result.visit.user.id)
+      render json: result.visit, include: ['score']
     else
-      render json: result[:error], status: result[:error][:errors].first[:status]
+      render json: result.error.hash, status: result.error.status
     end
   end
 

--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -4,9 +4,13 @@ class VisitsController < ApplicationController
   before_action :doorkeeper_authorize!
 
   def create
-    visit = GroundGame::Scenario::CreateVisit.new(visit_params, address, people, current_user).call
-    UpdateUsersLeaderboardsWorker.perform_async(visit.user.id)
-    render json: visit, include: ['score']
+    result = GroundGame::Scenario::CreateVisit.new(visit_params, address, people, current_user).call
+    if result[:success] == true
+      UpdateUsersLeaderboardsWorker.perform_async(result[:visit].user.id)
+      render json: result[:visit], include: ['score']
+    else
+      # TODO: Error
+    end
   end
 
   private

--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -9,7 +9,7 @@ class VisitsController < ApplicationController
       UpdateUsersLeaderboardsWorker.perform_async(result[:visit].user.id)
       render json: result[:visit], include: ['score']
     else
-      render json: result[:error], status: result[:error][:errors][:status]
+      render json: result[:error], status: result[:error][:errors].first[:status]
     end
   end
 

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -1,6 +1,6 @@
 class ErrorSerializer
   def self.serialize(error)
-    { errors: serialize_error(error) }
+    { errors: [serialize_error(error)] }
   end
 
   def self.serialize_error(error)

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -3,26 +3,28 @@ class ErrorSerializer
     { errors: [serialize_error(error)] }
   end
 
-  def self.serialize_error(error)
-    return serialize_argument_error(error) if error.class == ArgumentError
-    return serialize_record_not_found_error(error) if error.class == ActiveRecord::RecordNotFound
-  end
+  private
 
-  def self.serialize_argument_error(error)
-    {
-      id: "ARGUMENT_ERROR",
-      title: "Argument error",
-      detail: error.message,
-      status: 422
-    }
-  end
+    def self.serialize_error(error)
+      return serialize_argument_error(error) if error.class == ArgumentError
+      return serialize_record_not_found_error(error) if error.class == ActiveRecord::RecordNotFound
+    end
 
-  def self.serialize_record_not_found_error(error)
-    return {
-      id: "RECORD_NOT_FOUND",
-      title: "Record not found",
-      detail: error.message,
-      status: 404
-    }
-  end
+    def self.serialize_argument_error(error)
+      {
+        id: "ARGUMENT_ERROR",
+        title: "Argument error",
+        detail: error.message,
+        status: 422
+      }
+    end
+
+    def self.serialize_record_not_found_error(error)
+      return {
+        id: "RECORD_NOT_FOUND",
+        title: "Record not found",
+        detail: error.message,
+        status: 404
+      }
+    end
 end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -1,0 +1,28 @@
+class ErrorSerializer
+  def self.serialize(error)
+    { errors: serialize_error(error) }
+  end
+
+  def self.serialize_error(error)
+    return serialize_argument_error(error) if error.class == ArgumentError
+    return serialize_record_not_found_error(error) if error.class == ActiveRecord::RecordNotFound
+  end
+
+  def self.serialize_argument_error(error)
+    {
+      id: "ARGUMENT_ERROR",
+      title: "Argument error",
+      detail: error.message,
+      status: 422
+    }
+  end
+
+  def self.serialize_record_not_found_error(error)
+    return {
+      id: "RECORD_NOT_FOUND",
+      title: "Record not found",
+      detail: error.message,
+      status: 404
+    }
+  end
+end

--- a/lib/ground_game/scenario/create_visit.rb
+++ b/lib/ground_game/scenario/create_visit.rb
@@ -17,7 +17,9 @@ module GroundGame
             { success: true, visit: visit }
           end
         rescue ArgumentError => e
-          { success: false, error: e.message, error_code: 422 }
+          { success: false, error: ErrorSerializer.serialize(e) }
+        rescue ActiveRecord::RecordNotFound => e
+          { success: false, error: ErrorSerializer.serialize(e) }
         end
       end
 

--- a/lib/ground_game/scenario/create_visit.rb
+++ b/lib/ground_game/scenario/create_visit.rb
@@ -11,21 +11,25 @@ module GroundGame
       end
 
       def call
-        Visit.transaction do
-          visit = Visit.new(@visit_params)
-          visit.user = @current_user
+        begin
+          Visit.transaction do
+            visit = Visit.new(@visit_params)
+            visit.user = @current_user
 
-          address = create_or_update_address(@address_params, visit)
+            address = create_or_update_address(@address_params, visit)
 
-          people = create_or_update_people_for_address(@people_params, address, visit)
+            people = create_or_update_people_for_address(@people_params, address, visit)
 
-          address = update_most_supportive_resident(address, people)
-          address.save!
+            address = update_most_supportive_resident(address, people)
+            address.save!
 
-          visit.total_points = CreateScore.new(visit).call.total_points
-          visit.save!
+            visit.total_points = CreateScore.new(visit).call.total_points
+            visit.save!
 
-          visit
+            { success: true, visit: visit }
+          end
+        rescue
+          { success: false, error: true }
         end
       end
 

--- a/spec/lib/ground_game/scenario/create_visit_error_spec.rb
+++ b/spec/lib/ground_game/scenario/create_visit_error_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+require "ground_game/scenario/create_visit"
+
+module GroundGame
+  module Scenario
+
+    describe CreateVisitError do
+      before do
+        @argument_error = ArgumentError.new("A message")
+        @record_not_found_error = ActiveRecord::RecordNotFound.new("A message")
+      end
+      it "maps .id based on error class" do
+        expect(CreateVisitError.new(@argument_error).id).to eq "ARGUMENT_ERROR"
+        expect(CreateVisitError.new(@record_not_found_error).id).to eq "RECORD_NOT_FOUND"
+      end
+      it "maps .title based on error class" do
+        expect(CreateVisitError.new(@argument_error).title).to eq "Argument error"
+        expect(CreateVisitError.new(@record_not_found_error).title).to eq "Record not found"
+      end
+      it "maps .detail to error message" do
+        expect(CreateVisitError.new(@argument_error).detail).to eq "A message"
+        expect(CreateVisitError.new(@record_not_found_error).detail).to eq "A message"
+      end
+      it "maps .status based on error class" do
+        expect(CreateVisitError.new(@argument_error).status).to eq 422
+        expect(CreateVisitError.new(@record_not_found_error).status).to eq 404
+      end
+      it "keeps a serialized hash of the error" do
+        expect(CreateVisitError.new(@argument_error).hash).to eq ErrorSerializer.serialize(@argument_error)
+
+        expect(CreateVisitError.new(@record_not_found_error).hash).to eq ErrorSerializer.serialize(@record_not_found_error)
+      end
+    end
+  end
+end

--- a/spec/lib/ground_game/scenario/create_visit_result_spec.rb
+++ b/spec/lib/ground_game/scenario/create_visit_result_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+require "ground_game/scenario/create_visit"
+
+module GroundGame
+  module Scenario
+
+    describe CreateVisitResult do
+      before do
+        @visit = create(:visit)
+        @error = ArgumentError.new("A message")
+      end
+
+      describe "#success?" do
+        it "returns true if there was no error" do
+          expect(CreateVisitResult.new(visit: @visit).success?).to be true
+        end
+        it "returns false if there was an error" do
+          expect(CreateVisitResult.new(error: @error).success?).to be false
+        end
+      end
+
+    end
+  end
+end

--- a/spec/lib/ground_game/scenario/create_visit_spec.rb
+++ b/spec/lib/ground_game/scenario/create_visit_spec.rb
@@ -21,9 +21,9 @@ module GroundGame
             people_params = [{ id: 10 }]
 
             result = CreateVisit.new(visit_params, address_params, people_params, user).call
-            expect(result[:success]).to be true
-            expect(result[:visit]).not_to be_nil
-            expect(result[:error]).to be_nil
+            expect(result.success?).to be true
+            expect(result.visit).not_to be_nil
+            expect(result.error).to be_nil
           end
 
           it "computes and assigns the score" do
@@ -51,7 +51,7 @@ module GroundGame
               party_affiliation: "Democrat"
             }]
 
-            visit = CreateVisit.new(visit_params, address_params, people_params, user).call[:visit]
+            visit = CreateVisit.new(visit_params, address_params, people_params, user).call.visit
             expect(visit.total_points).not_to be_nil
           end
 
@@ -64,7 +64,7 @@ module GroundGame
               address_params = { id: 1 }
               people_params = []
 
-              visit = CreateVisit.new(visit_params, address_params, people_params, user).call[:visit]
+              visit = CreateVisit.new(visit_params, address_params, people_params, user).call.visit
               address_update = AddressUpdate.last
               expect(address_update.visit).to eq visit
               expect(address_update.address).to eq address
@@ -93,7 +93,7 @@ module GroundGame
                   party_affiliation: "Independent"
                 }]
 
-                visit = CreateVisit.new(visit_params, address_params, people_params, user).call[:visit]
+                visit = CreateVisit.new(visit_params, address_params, people_params, user).call.visit
 
                 first_person_update = PersonUpdate.find_by(person_id: 10)
                 expect(first_person_update).not_to be_nil
@@ -139,7 +139,7 @@ module GroundGame
                   party_affiliation: "Democrat"
                 }]
 
-                visit = CreateVisit.new(visit_params, address_params, people_params, user).call[:visit]
+                visit = CreateVisit.new(visit_params, address_params, people_params, user).call.visit
 
                 expect(visit.duration_sec).to eq 150
                 expect(visit.address.id).to eq 1
@@ -170,7 +170,7 @@ module GroundGame
                   party_affiliation: "Independent"
                 }]
 
-                visit = CreateVisit.new(visit_params, address_params, people_params, user).call[:visit]
+                visit = CreateVisit.new(visit_params, address_params, people_params, user).call.visit
 
                 first_person = Person.find_by(first_name: "John")
                 first_person_update = PersonUpdate.find_by(person: first_person)
@@ -216,7 +216,7 @@ module GroundGame
                   party_affiliation: "Democrat"
                 }]
 
-                visit = CreateVisit.new(visit_params, address_params, people_params, user).call[:visit]
+                visit = CreateVisit.new(visit_params, address_params, people_params, user).call.visit
 
                 expect(visit.duration_sec).to eq 150
                 expect(visit.address.id).to eq 1
@@ -240,7 +240,7 @@ module GroundGame
 
               people_params = []
 
-              visit = CreateVisit.new(visit_params, address_params, people_params, user).call[:visit]
+              visit = CreateVisit.new(visit_params, address_params, people_params, user).call.visit
 
               address_update = AddressUpdate.last
               expect(address_update.visit).to eq visit
@@ -266,7 +266,7 @@ module GroundGame
                 party_affiliation: "Democrat"
               }]
 
-              visit = CreateVisit.new(visit_params, address_params, people_params, user).call[:visit]
+              visit = CreateVisit.new(visit_params, address_params, people_params, user).call.visit
 
               expect(visit.duration_sec).to eq 150
 
@@ -301,9 +301,9 @@ module GroundGame
             people_params = []
 
             result = CreateVisit.new(visit_params, address_params, people_params, user).call
-            expect(result[:success]).to be false
-            expect(result[:visit]).to be_nil
-            expect(result[:error][:errors].length).to eq 1
+            expect(result.success?).to be false
+            expect(result.visit).to be_nil
+            expect(result.error).not_to be_nil
           end
 
           describe "error handling" do
@@ -316,12 +316,12 @@ module GroundGame
               address_params = { id: 10}
               people_params = [{ first_name: "John", last_name: "Doe", canvas_response: "invalid response" }]
 
-              error = CreateVisit.new(visit_params, address_params, people_params, user).call[:error][:errors].first
+              error = CreateVisit.new(visit_params, address_params, people_params, user).call.error
 
-              expect(error[:id]).to eq "ARGUMENT_ERROR"
-              expect(error[:title]).to eq "Argument error"
-              expect(error[:detail]).to eq "'invalid response' is not a valid canvas_response"
-              expect(error[:status]).to eq 422
+              expect(error.id).to eq "ARGUMENT_ERROR"
+              expect(error.title).to eq "Argument error"
+              expect(error.detail).to eq "'invalid response' is not a valid canvas_response"
+              expect(error.status).to eq 422
             end
 
             it "handles ActiveRecord::RecordNotFound with code 404" do
@@ -329,12 +329,12 @@ module GroundGame
               address_params = { id: 11}
               people_params = [{ first_name: "John", last_name: "Doe" }]
 
-              error = CreateVisit.new(visit_params, address_params, people_params, user).call[:error][:errors].first
+              error = CreateVisit.new(visit_params, address_params, people_params, user).call.error
 
-              expect(error[:id]).to eq "RECORD_NOT_FOUND"
-              expect(error[:title]).to eq "Record not found"
-              expect(error[:detail]).to eq "Couldn't find Address with 'id'=11"
-              expect(error[:status]).to eq 404
+              expect(error.id).to eq "RECORD_NOT_FOUND"
+              expect(error.title).to eq "Record not found"
+              expect(error.detail).to eq "Couldn't find Address with 'id'=11"
+              expect(error.status).to eq 404
             end
           end
 
@@ -348,7 +348,7 @@ module GroundGame
               people_params = []
 
               result = CreateVisit.new(visit_params, address_params, people_params, user).call
-              expect(result[:success]).to be false
+              expect(result.success?).to be false
 
               expect(Visit.count).to eq 0
               expect(Address.count).to eq 1
@@ -363,7 +363,7 @@ module GroundGame
               people_params = []
 
               result = CreateVisit.new(visit_params, address_params, people_params, user).call
-              expect(result[:success]).to be false
+              expect(result.success?).to be false
 
               expect(Visit.count).to eq 0
               expect(Address.count).to eq 0
@@ -380,7 +380,7 @@ module GroundGame
               people_params = [{ id: 2, first_name: "Jake", last_name: "Doe", canvas_response: "invalid_value" }]
 
               result = CreateVisit.new(visit_params, address_params, people_params, user).call
-              expect(result[:success]).to be false
+              expect(result.success?).to be false
 
               expect(Visit.count).to eq 0
 
@@ -407,7 +407,7 @@ module GroundGame
               ]
 
               result = CreateVisit.new(visit_params, address_params, people_params, user).call
-              expect(result[:success]).to be false
+              expect(result.success?).to be false
 
               expect(Visit.count).to eq 0
 

--- a/spec/lib/ground_game/scenario/create_visit_spec.rb
+++ b/spec/lib/ground_game/scenario/create_visit_spec.rb
@@ -10,342 +10,389 @@ module GroundGame
 
         let(:user) { create(:user, email: "josh@cookacademy.com") }
 
-        it "computes and assigns the score" do
-          address = create(:address, id: 1)
-          create(:person, id: 10, address: address, canvas_response: :unknown, party_affiliation: :unknown_affiliation)
+        context "when it succeeds" do
 
-          visit_params = { duration_sec: 150 }
-
-          address_params = {
-            id: 1,
-            latitude: 2.0,
-            longitude: 3.0,
-            city: "New York",
-            state_code: "NY",
-            zip_code: "12345",
-            street_1: "Test street",
-            street_2: "Additional data"
-          }
-
-          people_params = [{
-            id: 10,
-            first_name: "John",
-            last_name: "Doe",
-            canvas_response: "Leaning for",
-            party_affiliation: "Democrat"
-          }]
-
-          visit = CreateVisit.new(visit_params, address_params, people_params, user).call
-          expect(visit.total_points).not_to be_nil
-        end
-
-        context "when the address already exists" do
-
-          it "creates an address_update with proper contents" do
+          it "returns a visit" do
             address = create(:address, id: 1)
-            visit_params = { duration_sec: 150 }
+            create(:person, id: 10, address: address, canvas_response: :unknown, party_affiliation: :unknown_affiliation)
 
+            visit_params = { duration_sec: 150 }
             address_params = { id: 1 }
-            people_params = []
+            people_params = [{ id: 10 }]
 
-            visit = CreateVisit.new(visit_params, address_params, people_params, user).call
-            address_update = AddressUpdate.last
-            expect(address_update.visit).to eq visit
-            expect(address_update.address).to eq address
-            expect(address_update.modified?).to be true
+            result = CreateVisit.new(visit_params, address_params, people_params, user).call
+            expect(result[:success]).to be true
+            expect(result[:visit]).not_to be_nil
+            expect(result[:error]).to be_nil
           end
 
-          context "when the person already exists" do
-            it "creates a person_update with proper contents for each person" do
-              address = create(:address, id: 1)
-              create(:person, id: 10, address: address, canvas_response: :unknown, party_affiliation: :unknown_affiliation)
-              create(:person, id: 11, address: address, canvas_response: :leaning_against, party_affiliation: :republican_affiliation)
+          it "computes and assigns the score" do
+            address = create(:address, id: 1)
+            create(:person, id: 10, address: address, canvas_response: :unknown, party_affiliation: :unknown_affiliation)
 
-              visit_params = { duration_sec: 150 }
-
-              address_params = {
-                id: 1
-              }
-
-              people_params = [{
-                id: 10,
-                canvas_response: "Leaning for",
-                party_affiliation: "Democrat"
-              }, {
-                id: 11,
-                canvas_response: "Strongly for",
-                party_affiliation: "Independent"
-              }]
-
-              visit = CreateVisit.new(visit_params, address_params, people_params, user).call
-
-              first_person_update = PersonUpdate.find_by(person_id: 10)
-              expect(first_person_update).not_to be_nil
-              expect(first_person_update.visit).to eq visit
-              expect(first_person_update.modified?).to be true
-              expect(first_person_update.old_canvas_response).to eq "unknown"
-              expect(first_person_update.new_canvas_response).to eq "leaning_for"
-              expect(first_person_update.old_party_affiliation).to eq "unknown_affiliation"
-              expect(first_person_update.new_party_affiliation).to eq "democrat_affiliation"
-
-              second_person_update = PersonUpdate.find_by(person_id: 11)
-              expect(second_person_update).not_to be_nil
-              expect(second_person_update.visit).to eq visit
-              expect(second_person_update.modified?).to be true
-              expect(second_person_update.old_canvas_response).to eq "leaning_against"
-              expect(second_person_update.new_canvas_response).to eq "strongly_for"
-              expect(second_person_update.old_party_affiliation).to eq "republican_affiliation"
-              expect(second_person_update.new_party_affiliation).to eq "independent_affiliation"
-            end
-
-            it "creates a visit, updates the address, updates the person" do
-              address = create(:address, id: 1)
-              create(:person, id: 10, address: address, canvas_response: :unknown, party_affiliation: :unknown_affiliation)
-
-              visit_params = { duration_sec: 150 }
-
-              address_params = {
-                id: 1,
-                latitude: 2.0,
-                longitude: 3.0,
-                city: "New York",
-                state_code: "NY",
-                zip_code: "12345",
-                street_1: "Test street",
-                street_2: "Additional data"
-              }
-
-              people_params = [{
-                id: 10,
-                first_name: "John",
-                last_name: "Doe",
-                canvas_response: "Leaning for",
-                party_affiliation: "Democrat"
-              }]
-
-              visit = CreateVisit.new(visit_params, address_params, people_params, user).call
-
-              expect(visit.duration_sec).to eq 150
-              expect(visit.address.id).to eq 1
-              expect(visit.people.length).to eq 1
-              expect(visit.people.first.id).to eq 10
-            end
-          end
-
-          context "when the person does not exist" do
-
-            it "creates a person_update with proper contents for each person" do
-              address = create(:address, id: 1)
-              visit_params = { duration_sec: 150 }
-
-              address_params = {
-                id: 1
-              }
-
-              people_params = [{
-                first_name: "John",
-                last_name: "Doe",
-                canvas_response: "Leaning for",
-                party_affiliation: "Democrat"
-              }, {
-                first_name: "Jane",
-                last_name: "Doe",
-                canvas_response: "Strongly for",
-                party_affiliation: "Independent"
-              }]
-
-              visit = CreateVisit.new(visit_params, address_params, people_params, user).call
-              first_person = Person.find_by(first_name: "John")
-              first_person_update = PersonUpdate.find_by(person: first_person)
-              expect(first_person_update).not_to be_nil
-              expect(first_person_update.visit).to eq visit
-              expect(first_person_update.created?).to be true
-              expect(first_person_update.old_canvas_response).to eq "unknown"
-              expect(first_person_update.new_canvas_response).to eq "leaning_for"
-              expect(first_person_update.old_party_affiliation).to eq "unknown_affiliation"
-              expect(first_person_update.new_party_affiliation).to eq "democrat_affiliation"
-
-              second_person = Person.find_by(first_name: "Jane")
-              second_person_update = PersonUpdate.find_by(person: second_person)
-              expect(second_person_update).not_to be_nil
-              expect(second_person_update.visit).to eq visit
-              expect(second_person_update.created?).to be true
-              expect(second_person_update.old_canvas_response).to eq "unknown"
-              expect(second_person_update.new_canvas_response).to eq "strongly_for"
-              expect(second_person_update.old_party_affiliation).to eq "unknown_affiliation"
-              expect(second_person_update.new_party_affiliation).to eq "independent_affiliation"
-            end
-
-            it "creates a visit, updates the address and creates the person" do
-              create(:address, id: 1)
-
-              visit_params = { duration_sec: 150 }
-
-              address_params = {
-                id: 1,
-                latitude: 2.0,
-                longitude: 3.0,
-                city: "New York",
-                state_code: "NY",
-                zip_code: "12345",
-                street_1: "Test street",
-                street_2: "Additional data"
-              }
-
-              people_params = [{
-                first_name: "John",
-                last_name: "Doe",
-                canvas_response: "Leaning for",
-                party_affiliation: "Democrat"
-              }]
-
-              visit = CreateVisit.new(visit_params, address_params, people_params, user).call
-
-              expect(visit.duration_sec).to eq 150
-              expect(visit.address.id).to eq 1
-              expect(visit.people.length).to eq 1
-              expect(visit.people.first.first_name).to eq "John"
-            end
-          end
-        end
-
-        context "when the address doesn't exist"do
-          it "creates an address_update with proper contents", vcr: { cassette_name: "lib/ground_game/scenario/create_visit/creates_an_address_update_with_proper_contents" } do
             visit_params = { duration_sec: 150 }
 
             address_params = {
-              latitude: 40.771913,
-              longitude: -73.9673735,
-              street_1: "5th Avenue",
+              id: 1,
+              latitude: 2.0,
+              longitude: 3.0,
               city: "New York",
-              state_code: "NY"
-            }
-
-            people_params = []
-
-            visit = CreateVisit.new(visit_params, address_params, people_params, user).call
-            address_update = AddressUpdate.last
-            expect(address_update.visit).to eq visit
-            expect(address_update.address).to eq visit.address
-            expect(address_update.created?).to be true
-          end
-
-          it "creates the visit, the address and the people", vcr: { cassette_name: "lib/ground_game/scenario/create_visit/creates_the_visit_the_addres_and_the_people" } do
-            visit_params = { duration_sec: 150 }
-
-            address_params = {
-              latitude: 40.771913,
-              longitude: -73.9673735,
-              street_1: "5th Avenue",
-              city: "New York",
-              state_code: "NY"
+              state_code: "NY",
+              zip_code: "12345",
+              street_1: "Test street",
+              street_2: "Additional data"
             }
 
             people_params = [{
+              id: 10,
               first_name: "John",
               last_name: "Doe",
               canvas_response: "Leaning for",
               party_affiliation: "Democrat"
             }]
 
-            visit = CreateVisit.new(visit_params, address_params, people_params, user).call
-
-            expect(visit.duration_sec).to eq 150
-
-            address = visit.address
-            expect(address.latitude).to eq 40.771913
-            expect(address.longitude).to eq -73.9673735
-            expect(address.street_1)
-            expect(address.city).to eq "New York"
-            expect(address.street_1).to eq "5th Avenue"
-            expect(address.state_code).to eq "NY"
-
-            expect(address.usps_verified_street_1).to eq "5 AVENUE A"
-            expect(address.usps_verified_street_2).to eq ""
-            expect(address.usps_verified_city).to eq "NEW YORK"
-            expect(address.usps_verified_state).to eq "NY"
-            expect(address.usps_verified_zip).to eq "10009-7944"
-
-            expect(visit.people.length).to eq 1
-            expect(visit.people.first.first_name).to eq "John"
+            visit = CreateVisit.new(visit_params, address_params, people_params, user).call[:visit]
+            expect(visit.total_points).not_to be_nil
           end
+
+          context "when the address already exists" do
+
+            it "creates an address_update with proper contents" do
+              address = create(:address, id: 1)
+              visit_params = { duration_sec: 150 }
+
+              address_params = { id: 1 }
+              people_params = []
+
+              visit = CreateVisit.new(visit_params, address_params, people_params, user).call[:visit]
+              address_update = AddressUpdate.last
+              expect(address_update.visit).to eq visit
+              expect(address_update.address).to eq address
+              expect(address_update.modified?).to be true
+            end
+
+            context "when the person already exists" do
+              it "creates a person_update with proper contents for each person" do
+                address = create(:address, id: 1)
+                create(:person, id: 10, address: address, canvas_response: :unknown, party_affiliation: :unknown_affiliation)
+                create(:person, id: 11, address: address, canvas_response: :leaning_against, party_affiliation: :republican_affiliation)
+
+                visit_params = { duration_sec: 150 }
+
+                address_params = {
+                  id: 1
+                }
+
+                people_params = [{
+                  id: 10,
+                  canvas_response: "Leaning for",
+                  party_affiliation: "Democrat"
+                }, {
+                  id: 11,
+                  canvas_response: "Strongly for",
+                  party_affiliation: "Independent"
+                }]
+
+                visit = CreateVisit.new(visit_params, address_params, people_params, user).call[:visit]
+
+                first_person_update = PersonUpdate.find_by(person_id: 10)
+                expect(first_person_update).not_to be_nil
+                expect(first_person_update.visit).to eq visit
+                expect(first_person_update.modified?).to be true
+                expect(first_person_update.old_canvas_response).to eq "unknown"
+                expect(first_person_update.new_canvas_response).to eq "leaning_for"
+                expect(first_person_update.old_party_affiliation).to eq "unknown_affiliation"
+                expect(first_person_update.new_party_affiliation).to eq "democrat_affiliation"
+
+                second_person_update = PersonUpdate.find_by(person_id: 11)
+                expect(second_person_update).not_to be_nil
+                expect(second_person_update.visit).to eq visit
+                expect(second_person_update.modified?).to be true
+                expect(second_person_update.old_canvas_response).to eq "leaning_against"
+                expect(second_person_update.new_canvas_response).to eq "strongly_for"
+                expect(second_person_update.old_party_affiliation).to eq "republican_affiliation"
+                expect(second_person_update.new_party_affiliation).to eq "independent_affiliation"
+              end
+
+              it "creates a visit, updates the address, updates the person" do
+                address = create(:address, id: 1)
+                create(:person, id: 10, address: address, canvas_response: :unknown, party_affiliation: :unknown_affiliation)
+
+                visit_params = { duration_sec: 150 }
+
+                address_params = {
+                  id: 1,
+                  latitude: 2.0,
+                  longitude: 3.0,
+                  city: "New York",
+                  state_code: "NY",
+                  zip_code: "12345",
+                  street_1: "Test street",
+                  street_2: "Additional data"
+                }
+
+                people_params = [{
+                  id: 10,
+                  first_name: "John",
+                  last_name: "Doe",
+                  canvas_response: "Leaning for",
+                  party_affiliation: "Democrat"
+                }]
+
+                visit = CreateVisit.new(visit_params, address_params, people_params, user).call[:visit]
+
+                expect(visit.duration_sec).to eq 150
+                expect(visit.address.id).to eq 1
+                expect(visit.people.length).to eq 1
+                expect(visit.people.first.id).to eq 10
+              end
+            end
+
+            context "when the person does not exist" do
+
+              it "creates a person_update with proper contents for each person" do
+                address = create(:address, id: 1)
+                visit_params = { duration_sec: 150 }
+
+                address_params = {
+                  id: 1
+                }
+
+                people_params = [{
+                  first_name: "John",
+                  last_name: "Doe",
+                  canvas_response: "Leaning for",
+                  party_affiliation: "Democrat"
+                }, {
+                  first_name: "Jane",
+                  last_name: "Doe",
+                  canvas_response: "Strongly for",
+                  party_affiliation: "Independent"
+                }]
+
+                visit = CreateVisit.new(visit_params, address_params, people_params, user).call[:visit]
+
+                first_person = Person.find_by(first_name: "John")
+                first_person_update = PersonUpdate.find_by(person: first_person)
+                expect(first_person_update).not_to be_nil
+                expect(first_person_update.visit).to eq visit
+                expect(first_person_update.created?).to be true
+                expect(first_person_update.old_canvas_response).to eq "unknown"
+                expect(first_person_update.new_canvas_response).to eq "leaning_for"
+                expect(first_person_update.old_party_affiliation).to eq "unknown_affiliation"
+                expect(first_person_update.new_party_affiliation).to eq "democrat_affiliation"
+
+                second_person = Person.find_by(first_name: "Jane")
+                second_person_update = PersonUpdate.find_by(person: second_person)
+                expect(second_person_update).not_to be_nil
+                expect(second_person_update.visit).to eq visit
+                expect(second_person_update.created?).to be true
+                expect(second_person_update.old_canvas_response).to eq "unknown"
+                expect(second_person_update.new_canvas_response).to eq "strongly_for"
+                expect(second_person_update.old_party_affiliation).to eq "unknown_affiliation"
+                expect(second_person_update.new_party_affiliation).to eq "independent_affiliation"
+              end
+
+              it "creates a visit, updates the address and creates the person" do
+                create(:address, id: 1)
+
+                visit_params = { duration_sec: 150 }
+
+                address_params = {
+                  id: 1,
+                  latitude: 2.0,
+                  longitude: 3.0,
+                  city: "New York",
+                  state_code: "NY",
+                  zip_code: "12345",
+                  street_1: "Test street",
+                  street_2: "Additional data"
+                }
+
+                people_params = [{
+                  first_name: "John",
+                  last_name: "Doe",
+                  canvas_response: "Leaning for",
+                  party_affiliation: "Democrat"
+                }]
+
+                visit = CreateVisit.new(visit_params, address_params, people_params, user).call[:visit]
+
+                expect(visit.duration_sec).to eq 150
+                expect(visit.address.id).to eq 1
+                expect(visit.people.length).to eq 1
+                expect(visit.people.first.first_name).to eq "John"
+              end
+            end
+          end
+
+          context "when the address doesn't exist"do
+            it "creates an address_update with proper contents", vcr: { cassette_name: "lib/ground_game/scenario/create_visit/creates_an_address_update_with_proper_contents" } do
+              visit_params = { duration_sec: 150 }
+
+              address_params = {
+                latitude: 40.771913,
+                longitude: -73.9673735,
+                street_1: "5th Avenue",
+                city: "New York",
+                state_code: "NY"
+              }
+
+              people_params = []
+
+              visit = CreateVisit.new(visit_params, address_params, people_params, user).call[:visit]
+
+              address_update = AddressUpdate.last
+              expect(address_update.visit).to eq visit
+              expect(address_update.address).to eq visit.address
+              expect(address_update.created?).to be true
+            end
+
+            it "creates the visit, the address and the people", vcr: { cassette_name: "lib/ground_game/scenario/create_visit/creates_the_visit_the_addres_and_the_people" } do
+              visit_params = { duration_sec: 150 }
+
+              address_params = {
+                latitude: 40.771913,
+                longitude: -73.9673735,
+                street_1: "5th Avenue",
+                city: "New York",
+                state_code: "NY"
+              }
+
+              people_params = [{
+                first_name: "John",
+                last_name: "Doe",
+                canvas_response: "Leaning for",
+                party_affiliation: "Democrat"
+              }]
+
+              visit = CreateVisit.new(visit_params, address_params, people_params, user).call[:visit]
+
+              expect(visit.duration_sec).to eq 150
+
+              address = visit.address
+              expect(address.latitude).to eq 40.771913
+              expect(address.longitude).to eq -73.9673735
+              expect(address.street_1)
+              expect(address.city).to eq "New York"
+              expect(address.street_1).to eq "5th Avenue"
+              expect(address.state_code).to eq "NY"
+
+              expect(address.usps_verified_street_1).to eq "5 AVENUE A"
+              expect(address.usps_verified_street_2).to eq ""
+              expect(address.usps_verified_city).to eq "NEW YORK"
+              expect(address.usps_verified_state).to eq "NY"
+              expect(address.usps_verified_zip).to eq "10009-7944"
+
+              expect(visit.people.length).to eq 1
+              expect(visit.people.first.first_name).to eq "John"
+            end
+          end
+
         end
 
         context "when it fails" do
 
-          it "cleans up everything when address update fails" do
+          it "returns an error object" do
             create(:address, id: 1, latitude: 1, longitude: 2)
             visit_params = { duration_sec: 150 }
 
             address_params = { id: 1, latitude: 1, longitude: 3, best_canvas_response: "invalid_value" }
             people_params = []
 
-            expect { CreateVisit.new(visit_params, address_params, people_params, user).call }.to raise_error ArgumentError
-            expect(Visit.count).to eq 0
-            expect(Address.count).to eq 1
-            expect(Address.first.longitude).to eq 2
-            expect(Person.count).to eq 0
-            expect(Score.count).to eq 0
+            result = CreateVisit.new(visit_params, address_params, people_params, user).call
+            expect(result[:success]).to be false
+            expect(result[:visit]).to be_nil
+            expect(result[:error]).not_to be_nil
           end
 
-          it "cleans up everything when address creation fails", vcr: { cassette_name: "lib/ground_game/scenario/create_visit/cleans_up_everything_when_address_update_fails" } do
-            visit_params = { duration_sec: 150 }
-            address_params = { best_canvas_response: "invalid_value" }
-            people_params = []
-            expect { CreateVisit.new(visit_params, address_params, people_params, user).call }.to raise_error ArgumentError
-            expect(Visit.count).to eq 0
-            expect(Address.count).to eq 0
-            expect(Person.count).to eq 0
-            expect(Score.count).to eq 0
+          describe "error handling" do
           end
 
-          it "cleans up everything when person update fails" do
-            address = create(:address, id: 1, latitude: 1, longitude: 2)
-            create(:person, id: 2, first_name: "John", last_name: "Doe", address: address)
+          describe "cleanup" do
 
-            visit_params = { duration_sec: 150 }
-            address_params = { id: 1, latitude: 1, longitude: 3 }
-            people_params = [{ id: 2, first_name: "Jake", last_name: "Doe", canvas_response: "invalid_value" }]
+            it "cleans up everything when address update fails" do
+              create(:address, id: 1, latitude: 1, longitude: 2)
+              visit_params = { duration_sec: 150 }
 
-            expect { CreateVisit.new(visit_params, address_params, people_params, user).call }.to raise_error ArgumentError
+              address_params = { id: 1, latitude: 1, longitude: 3, best_canvas_response: "invalid_value" }
+              people_params = []
 
-            expect(Visit.count).to eq 0
+              result = CreateVisit.new(visit_params, address_params, people_params, user).call
+              expect(result[:success]).to be false
 
-            expect(Address.count).to eq 1
+              expect(Visit.count).to eq 0
+              expect(Address.count).to eq 1
+              expect(Address.first.longitude).to eq 2
+              expect(Person.count).to eq 0
+              expect(Score.count).to eq 0
+            end
 
-            address = Address.last
-            expect(address.longitude).to eq 2
+            it "cleans up everything when address creation fails", vcr: { cassette_name: "lib/ground_game/scenario/create_visit/cleans_up_everything_when_address_update_fails" } do
+              visit_params = { duration_sec: 150 }
+              address_params = { best_canvas_response: "invalid_value" }
+              people_params = []
 
-            expect(Person.count).to eq 1
-            expect(Person.last.first_name).to eq "John"
+              result = CreateVisit.new(visit_params, address_params, people_params, user).call
+              expect(result[:success]).to be false
 
-            expect(Score.count).to eq 0
-          end
+              expect(Visit.count).to eq 0
+              expect(Address.count).to eq 0
+              expect(Person.count).to eq 0
+              expect(Score.count).to eq 0
+            end
 
-          it "cleans up everything when person creation fails" do
-            address = create(:address, id: 1, latitude: 1, longitude: 2)
-            create(:person, id: 2, first_name: "John", last_name: "Doe", address: address)
+            it "cleans up everything when person update fails" do
+              address = create(:address, id: 1, latitude: 1, longitude: 2)
+              create(:person, id: 2, first_name: "John", last_name: "Doe", address: address)
 
-            visit_params = { duration_sec: 150 }
-            address_params = { id: 1, latitude: 1, longitude: 3 }
-            people_params = [
-              { id: 2, first_name: "Jake", last_name: "Doe" },
-              { first_name: "John", last_name: "Smith", canvas_response: "invalid_value" }
-            ]
+              visit_params = { duration_sec: 150 }
+              address_params = { id: 1, latitude: 1, longitude: 3 }
+              people_params = [{ id: 2, first_name: "Jake", last_name: "Doe", canvas_response: "invalid_value" }]
 
-            expect { CreateVisit.new(visit_params, address_params, people_params, user).call }.to raise_error ArgumentError
+              result = CreateVisit.new(visit_params, address_params, people_params, user).call
+              expect(result[:success]).to be false
 
-            expect(Visit.count).to eq 0
+              expect(Visit.count).to eq 0
 
-            expect(Address.count).to eq 1
+              expect(Address.count).to eq 1
 
-            address = Address.last
-            expect(address.longitude).to eq 2
+              address = Address.last
+              expect(address.longitude).to eq 2
 
-            expect(Person.count).to eq 1
-            expect(Person.last.first_name).to eq "John"
+              expect(Person.count).to eq 1
+              expect(Person.last.first_name).to eq "John"
 
-            expect(Score.count).to eq 0
+              expect(Score.count).to eq 0
+            end
+
+            it "cleans up everything when person creation fails" do
+              address = create(:address, id: 1, latitude: 1, longitude: 2)
+              create(:person, id: 2, first_name: "John", last_name: "Doe", address: address)
+
+              visit_params = { duration_sec: 150 }
+              address_params = { id: 1, latitude: 1, longitude: 3 }
+              people_params = [
+                { id: 2, first_name: "Jake", last_name: "Doe" },
+                { first_name: "John", last_name: "Smith", canvas_response: "invalid_value" }
+              ]
+
+              result = CreateVisit.new(visit_params, address_params, people_params, user).call
+              expect(result[:success]).to be false
+
+              expect(Visit.count).to eq 0
+
+              expect(Address.count).to eq 1
+
+              address = Address.last
+              expect(address.longitude).to eq 2
+
+              expect(Person.count).to eq 1
+              expect(Person.last.first_name).to eq "John"
+
+              expect(Score.count).to eq 0
+            end
+
           end
         end
       end

--- a/spec/lib/ground_game/scenario/create_visit_spec.rb
+++ b/spec/lib/ground_game/scenario/create_visit_spec.rb
@@ -308,31 +308,33 @@ module GroundGame
 
           describe "error handling" do
             before do
-              create(:address, id: 1, latitude: 1, longitude: 2)
-              visit_params = { duration_sec: 150 }
-
-              address_params = { id: 1, latitude: 1, longitude: 3, best_canvas_response: "invalid_value" }
-              people_params = []
-
-              @create_visit_instance = CreateVisit.new(visit_params, address_params, people_params, user)
+              create(:address, id: 10, latitude: 40.771913, longitude: -73.9673735, street_1: "5th Avenue", city: "New York", state_code: "NY")
             end
 
             it "handles ArgumentError with code 422" do
-              allow(@create_visit_instance).to receive(:create_visit).and_raise ArgumentError.new("Error message")
-              result = @create_visit_instance.call
+              visit_params = { duration_sec: 150 }
+              address_params = { id: 10}
+              people_params = [{ first_name: "John", last_name: "Doe", canvas_response: "invalid response" }]
 
-              expect(result[:error][:errors][:detail]).to eq "Error message"
-              expect(result[:error][:errors][:status]).to eq 422
+              error = CreateVisit.new(visit_params, address_params, people_params, user).call[:error][:errors]
+
+              expect(error[:id]).to eq "ARGUMENT_ERROR"
+              expect(error[:title]).to eq "Argument error"
+              expect(error[:detail]).to eq "'invalid response' is not a valid canvas_response"
+              expect(error[:status]).to eq 422
             end
 
-            it "handles EasyPost:Error with code 422"
-
             it "handles ActiveRecord::RecordNotFound with code 404" do
-              allow(@create_visit_instance).to receive(:create_visit).and_raise ActiveRecord::RecordNotFound.new("Error message")
-              result = @create_visit_instance.call
+              visit_params = { duration_sec: 150 }
+              address_params = { id: 11}
+              people_params = [{ first_name: "John", last_name: "Doe" }]
 
-              expect(result[:error][:errors][:detail]).to eq "Error message"
-              expect(result[:error][:errors][:status]).to eq 404
+              error = CreateVisit.new(visit_params, address_params, people_params, user).call[:error][:errors]
+
+              expect(error[:id]).to eq "RECORD_NOT_FOUND"
+              expect(error[:title]).to eq "Record not found"
+              expect(error[:detail]).to eq "Couldn't find Address with 'id'=11"
+              expect(error[:status]).to eq 404
             end
           end
 
@@ -419,7 +421,6 @@ module GroundGame
 
               expect(Score.count).to eq 0
             end
-
           end
         end
       end

--- a/spec/lib/ground_game/scenario/create_visit_spec.rb
+++ b/spec/lib/ground_game/scenario/create_visit_spec.rb
@@ -321,8 +321,18 @@ module GroundGame
               allow(@create_visit_instance).to receive(:create_visit).and_raise ArgumentError.new("Error message")
               result = @create_visit_instance.call
 
-              expect(result[:error]).to eq "Error message"
-              expect(result[:error_code]).to eq 422
+              expect(result[:error][:errors][:detail]).to eq "Error message"
+              expect(result[:error][:errors][:status]).to eq 422
+            end
+
+            it "handles EasyPost:Error with code 422"
+
+            it "handles ActiveRecord::RecordNotFound with code 404" do
+              allow(@create_visit_instance).to receive(:create_visit).and_raise ActiveRecord::RecordNotFound.new("Error message")
+              result = @create_visit_instance.call
+
+              expect(result[:error][:errors][:detail]).to eq "Error message"
+              expect(result[:error][:errors][:status]).to eq 404
             end
           end
 

--- a/spec/lib/ground_game/scenario/create_visit_spec.rb
+++ b/spec/lib/ground_game/scenario/create_visit_spec.rb
@@ -303,7 +303,7 @@ module GroundGame
             result = CreateVisit.new(visit_params, address_params, people_params, user).call
             expect(result[:success]).to be false
             expect(result[:visit]).to be_nil
-            expect(result[:error]).not_to be_nil
+            expect(result[:error][:errors].length).to eq 1
           end
 
           describe "error handling" do
@@ -316,7 +316,7 @@ module GroundGame
               address_params = { id: 10}
               people_params = [{ first_name: "John", last_name: "Doe", canvas_response: "invalid response" }]
 
-              error = CreateVisit.new(visit_params, address_params, people_params, user).call[:error][:errors]
+              error = CreateVisit.new(visit_params, address_params, people_params, user).call[:error][:errors].first
 
               expect(error[:id]).to eq "ARGUMENT_ERROR"
               expect(error[:title]).to eq "Argument error"
@@ -329,7 +329,7 @@ module GroundGame
               address_params = { id: 11}
               people_params = [{ first_name: "John", last_name: "Doe" }]
 
-              error = CreateVisit.new(visit_params, address_params, people_params, user).call[:error][:errors]
+              error = CreateVisit.new(visit_params, address_params, people_params, user).call[:error][:errors].first
 
               expect(error[:id]).to eq "RECORD_NOT_FOUND"
               expect(error[:title]).to eq "Record not found"

--- a/spec/lib/ground_game/scenario/create_visit_spec.rb
+++ b/spec/lib/ground_game/scenario/create_visit_spec.rb
@@ -307,6 +307,23 @@ module GroundGame
           end
 
           describe "error handling" do
+            before do
+              create(:address, id: 1, latitude: 1, longitude: 2)
+              visit_params = { duration_sec: 150 }
+
+              address_params = { id: 1, latitude: 1, longitude: 3, best_canvas_response: "invalid_value" }
+              people_params = []
+
+              @create_visit_instance = CreateVisit.new(visit_params, address_params, people_params, user)
+            end
+
+            it "handles ArgumentError with code 422" do
+              allow(@create_visit_instance).to receive(:create_visit).and_raise ArgumentError.new("Error message")
+              result = @create_visit_instance.call
+
+              expect(result[:error]).to eq "Error message"
+              expect(result[:error_code]).to eq 422
+            end
           end
 
           describe "cleanup" do

--- a/spec/requests/api/visit_spec.rb
+++ b/spec/requests/api/visit_spec.rb
@@ -405,7 +405,22 @@ describe "Visit API" do
       end
 
       context "when it fails creating the visit" do
-        it "should return an error response"
+        it "should return an error response" do
+          address = create(:address, id: 1)
+
+          authenticated_post "visits", {
+            data: {
+              attributes: { duration_sec: 200 },
+              relationships: { address: { data: { id: 1, type: "addresses" } }, person: { data: { id: 10, type: "people" } } }
+            },
+            included: [ { type: "addresses", id: 1, attributes: { } }, { type: "people", id: 10, attributes: {} } ]
+          }, token
+          expect(last_response.status).to eq 404
+          expect(json.errors.id).to eq "RECORD_NOT_FOUND"
+          expect(json.errors.title).to eq "Record not found"
+          expect(json.errors.detail).to eq "Couldn't find Person with 'id'=10"
+          expect(json.errors.status).to eq 404
+        end
       end
     end
   end

--- a/spec/requests/api/visit_spec.rb
+++ b/spec/requests/api/visit_spec.rb
@@ -416,10 +416,12 @@ describe "Visit API" do
             included: [ { type: "addresses", id: 1, attributes: { } }, { type: "people", id: 10, attributes: {} } ]
           }, token
           expect(last_response.status).to eq 404
-          expect(json.errors.id).to eq "RECORD_NOT_FOUND"
-          expect(json.errors.title).to eq "Record not found"
-          expect(json.errors.detail).to eq "Couldn't find Person with 'id'=10"
-          expect(json.errors.status).to eq 404
+          expect(json.errors.length).to eq 1
+          error = json.errors.first
+          expect(error.id).to eq "RECORD_NOT_FOUND"
+          expect(error.title).to eq "Record not found"
+          expect(error.detail).to eq "Couldn't find Person with 'id'=10"
+          expect(error.status).to eq 404
         end
       end
     end

--- a/spec/requests/api/visit_spec.rb
+++ b/spec/requests/api/visit_spec.rb
@@ -403,6 +403,10 @@ describe "Visit API" do
           expect(new_address.best_canvas_response).to eq new_person.canvas_response
         end
       end
+
+      context "when it fails creating the visit" do
+        it "should return an error response"
+      end
     end
   end
 end

--- a/spec/serializers/error_serializer_spec.rb
+++ b/spec/serializers/error_serializer_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe ErrorSerializer do
+  describe  ".serialize" do
+    it "can serialize ArgumentError" do
+      argument_error = ArgumentError.new("A message")
+      result = ErrorSerializer.serialize(argument_error)
+      expect(result[:errors]).not_to be_nil
+      expect(result[:errors].length).to eq 1
+
+      error = result[:errors].first
+      expect(error[:id]).to eq "ARGUMENT_ERROR"
+      expect(error[:title]).to eq "Argument error"
+      expect(error[:detail]).to eq "A message"
+      expect(error[:status]).to eq 422
+    end
+
+    it "can serialize ActiveRecord::RecordNotFound error" do
+      record_not_found_error = ActiveRecord::RecordNotFound.new("A message")
+      result = ErrorSerializer.serialize(record_not_found_error)
+      expect(result[:errors]).not_to be_nil
+      expect(result[:errors].length).to eq 1
+
+      error = result[:errors].first
+      expect(error[:id]).to eq "RECORD_NOT_FOUND"
+      expect(error[:title]).to eq "Record not found"
+      expect(error[:detail]).to eq "A message"
+      expect(error[:status]).to eq 404
+    end
+  end
+end


### PR DESCRIPTION
- [Asana task: Output errors as an API response if visit creation fails](https://app.asana.com/0/60127409159606/60173033393718)
# Description

This PR adds error handling and rendering to the Visit API endpoint.

It does so by wrapping the code in the `CreateVisit` scenario into a begin-rescue block which rescues from errors we currently support.

The error is then passed into a new `ErrorSerializer` singleton class, which, based on the `Error.class` returns a hash containing the proper error information. 

This is all wrapped into two helper classes - `CreateVisitResult`, which holds the visit, the error and the `success?` variable, as well as `CreateVisitError`, which wraps the result of `ErrorSerializer` and allows us to easily access the error properties.
# Error format

``` JavaScript
{
  errors: [{
    id: "DASHERIZED_CAPITALIZED_ERROR_NAME",
    title: "User friendly error name",
    detail: "Value of Error.message",
    status: HTTP_CODE_IN_INTEGER_FORMAT
  }]
}
```

This format is consistent with the JSON API specification for errors. The root object should be called "errors". It should be an array, even if it's just a single error, which is our case.
- [JSON API spec for errors](http://jsonapi.org/format/#errors)
# Errors we are currently handling
## `ActiveRecord::RecordNotFound` with code 404

This happens if we set the visit to be updating (not creating) a person or an address, but the subject doesn't exist (for instance, if it somehow got deleted while the user was in the process of logging the visit).
## `ArgumentError` with code 422

This error happens if we somehow set `canvas_response` to an invalid value (not defined in the enum). I don't think it's possible for it to happen currently, but we could accidentally introduce an error on the client that triggers it.
# Potential errors that could be handled, but currently cannot be triggered
## `EasyPost:Error` with code 422"

At the moment, when creating/updating an address, we will attempt to fetch the address via easypost. If it works, we will fill out the `usps_` fields with the information we retrieve. If it doesn't, nothing will happen. The address will simply be saved as is. This means the error will never get thrown, except internally.
## ActiveRecord::RecordInvalid with code 422"

Technically, the only place this could happen is if we somehow set `PersonUpdate#new_canvas_response` to nil. However, this is being set from the value of `Person.canvas_response` which has a valid default set on the DB level, so it will never be nil, except if we somehow explicitly set it to nil from the client (in which case, the enum will kick in and an `ArgumentError` will be thrown instead.
