### PR TITLE
Allow setting of certain `address.best_canvas_response` values directly  through the visit API

### DIFF
--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -21,7 +21,7 @@ class VisitsController < ApplicationController
 
   def address
     address_params = included_records.select{ |record| record[:type] == "addresses" }.first
-    address = address_params.fetch(:attributes, {}).permit(:latitude, :longitude, :street_1, :street_2, :city, :state_code, :zip_code)
+    address = address_params.fetch(:attributes, {}).permit(:best_canvas_response, :latitude, :longitude, :street_1, :street_2, :city, :state_code, :zip_code)
     address_id = address_params.fetch(:id, nil)
     address = address.merge(id: address_id) if address_id
     address

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -49,7 +49,19 @@ class Address < ActiveRecord::Base
 
   def self.existing_with_params(id, params)
     address = Address.find(id)
-    address.assign_attributes(params)
-    address
+    if best_canvas_response_value_valid(params[:best_canvas_response])
+      address.assign_attributes(params)
+      return address
+    else
+      raise ArgumentError.new("Invalid argument #{params[:best_canvas_response]} for address.best_canvas_response")
+    end
+  end
+
+  def self.best_canvas_response_value_valid(value)
+    value.nil? or allowed_best_canvas_response_values_for_setting_directly.include? value.to_sym
+  end
+
+  def self.allowed_best_canvas_response_values_for_setting_directly
+    [:asked_to_leave, :unknown, :not_yet_visited, :not_home]
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -62,6 +62,6 @@ class Address < ActiveRecord::Base
   end
 
   def self.allowed_best_canvas_response_values_for_setting_directly
-    [:asked_to_leave, :unknown, :not_yet_visited, :not_home]
+    [:asked_to_leave, :not_yet_visited, :not_home]
   end
 end

--- a/lib/ground_game/scenario/create_visit.rb
+++ b/lib/ground_game/scenario/create_visit.rb
@@ -126,13 +126,7 @@ module GroundGame
 
         def update_most_supportive_resident(address, people)
           most_supportive_resident = person_with_highest_rated_canvas_response(people)
-
-          if most_supportive_resident
-            address.assign_most_supportive_resident(most_supportive_resident)
-          elsif not address.most_supportive_resident
-            address.best_canvas_response = :not_home
-          end
-
+          address.assign_most_supportive_resident(most_supportive_resident) if most_supportive_resident
           address
         end
 

--- a/spec/lib/ground_game/scenario/create_visit_spec.rb
+++ b/spec/lib/ground_game/scenario/create_visit_spec.rb
@@ -423,6 +423,70 @@ module GroundGame
             end
           end
         end
+
+        describe "setting 'address.best_canvas_response' directly" do
+          before do
+            @address = create(:address, id: 1)
+          end
+
+          def create_visit_with_address_best_canvas_response_set_to(best_canvas_response)
+            visit_params = { duration_sec: 200 }
+            address_params = { id: 1, best_canvas_response: best_canvas_response }
+            people_params = []
+
+            CreateVisit.new(visit_params, address_params, people_params, user).call
+          end
+
+          it "should be allowed for 'asked_to_leave'" do
+            result = create_visit_with_address_best_canvas_response_set_to "asked_to_leave"
+            expect(@address.reload.asked_to_leave?).to be true
+          end
+
+          it "should be allowed for 'unknown'" do
+            create_visit_with_address_best_canvas_response_set_to "unknown"
+            expect(@address.reload.unknown?).to be true
+          end
+
+          it "should be allowed for 'not_home'" do
+            create_visit_with_address_best_canvas_response_set_to "not_home"
+            expect(@address.reload.not_home?).to be true
+          end
+
+          it "should be allowed for 'not_yet_visited" do
+            create_visit_with_address_best_canvas_response_set_to "not_yet_visited"
+            expect(@address.reload.not_yet_visited?).to be true
+          end
+
+          it "should not be allowed for 'strongly_for'" do
+            result = create_visit_with_address_best_canvas_response_set_to "strongly_for"
+            expect(@address.reload.strongly_for?).to be false
+            expect(result.error.id).to eq "ARGUMENT_ERROR"
+          end
+
+          it "should not be allowed for 'leaning_for'" do
+            result = create_visit_with_address_best_canvas_response_set_to "leaning_for"
+            expect(@address.reload.leaning_for?).to be false
+            expect(result.error.id).to eq "ARGUMENT_ERROR"
+          end
+
+          it "should not be allowed for 'undecided'" do
+            result = create_visit_with_address_best_canvas_response_set_to "undecided"
+            expect(@address.reload.undecided?).to be false
+            expect(result.error.id).to eq "ARGUMENT_ERROR"
+          end
+
+          it "should not be allowed for 'leaning_against'" do
+            result = create_visit_with_address_best_canvas_response_set_to "leaning_against"
+            expect(@address.reload.leaning_against?).to be false
+            expect(result.error.id).to eq "ARGUMENT_ERROR"
+          end
+
+          it "should not be allowed for 'strongly_against'" do
+            result = create_visit_with_address_best_canvas_response_set_to "strongly_against"
+            expect(@address.reload.strongly_against?).to be false
+            expect(result.error.id).to eq "ARGUMENT_ERROR"
+          end
+        end
       end
     end
   end

--- a/spec/lib/ground_game/scenario/create_visit_spec.rb
+++ b/spec/lib/ground_game/scenario/create_visit_spec.rb
@@ -442,11 +442,6 @@ module GroundGame
             expect(@address.reload.asked_to_leave?).to be true
           end
 
-          it "should be allowed for 'unknown'" do
-            create_visit_with_address_best_canvas_response_set_to "unknown"
-            expect(@address.reload.unknown?).to be true
-          end
-
           it "should be allowed for 'not_home'" do
             create_visit_with_address_best_canvas_response_set_to "not_home"
             expect(@address.reload.not_home?).to be true
@@ -455,6 +450,11 @@ module GroundGame
           it "should be allowed for 'not_yet_visited" do
             create_visit_with_address_best_canvas_response_set_to "not_yet_visited"
             expect(@address.reload.not_yet_visited?).to be true
+          end
+
+          it "should not be allowed for 'unknown'" do
+            create_visit_with_address_best_canvas_response_set_to "unknown"
+            expect(@address.reload.unknown?).to be false
           end
 
           it "should not be allowed for 'strongly_for'" do

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -104,5 +104,14 @@ describe Address do
       expect(address.latitude).to eq 1
       expect(address.longitude).to eq 1
     end
+
+    it "should raise an error if there's an invalid 'best_canvas_response' parameter value" do
+      create(:address, id: 1, latitude: 0, longitude: 0)
+      params = {
+        id: 1,
+        best_canvas_response: "strongly_for"
+      }
+      expect { Address.new_or_existing_from_params(params) }.to raise_error ArgumentError
+    end
   end
 end

--- a/spec/requests/api/visit_spec.rb
+++ b/spec/requests/api/visit_spec.rb
@@ -40,6 +40,67 @@ describe "Visit API" do
         expect(score_json.points_for_knock).to eq 5
       end
 
+      describe "setting 'address.best_canvas_response' directly" do
+        before do
+          @address = create(:address, id: 1)
+        end
+
+        def post_visit_with_address_best_canvas_response_set_to(best_canvas_response)
+          authenticated_post "visits", {
+            data: {
+              attributes: { duration_sec: 200 },
+              relationships: { address: { data: { id: 1, type: "addresses" } } }
+            },
+            included: [ { id: 1, type: "addresses", attributes: { best_canvas_response: best_canvas_response } } ]
+          }, token
+        end
+
+        it "should be allowed for 'asked_to_leave'" do
+          post_visit_with_address_best_canvas_response_set_to "asked_to_leave"
+          expect(@address.reload.asked_to_leave?).to be true
+        end
+
+        it "should be allowed for 'unknown'" do
+          post_visit_with_address_best_canvas_response_set_to "unknown"
+          expect(@address.reload.unknown?).to be true
+        end
+
+        it "should be allowed for 'not_home'" do
+          post_visit_with_address_best_canvas_response_set_to "not_home"
+          expect(@address.reload.not_home?).to be true
+        end
+
+        it "should be allowed for 'not_yet_visited" do
+          post_visit_with_address_best_canvas_response_set_to "not_yet_visited"
+          expect(@address.reload.not_yet_visited?).to be true
+        end
+
+        it "should not be allowed for 'strongly_for'" do
+          post_visit_with_address_best_canvas_response_set_to "strongly_for"
+          expect(@address.reload.strongly_for?).to be false
+        end
+
+        it "should not be allowed for 'leaning_for'" do
+          post_visit_with_address_best_canvas_response_set_to "leaning_for"
+          expect(@address.reload.leaning_for?).to be false
+        end
+
+        it "should not be allowed for 'undecided'" do
+          post_visit_with_address_best_canvas_response_set_to "undecided"
+          expect(@address.reload.undecided?).to be false
+        end
+
+        it "should not be allowed for 'leaning_against'" do
+          post_visit_with_address_best_canvas_response_set_to "leaning_against"
+          expect(@address.reload.leaning_against?).to be false
+        end
+
+        it "should not be allowed for 'strongly_against'" do
+          post_visit_with_address_best_canvas_response_set_to "strongly_against"
+          expect(@address.reload.strongly_against?).to be false
+        end
+      end
+
       it "should update the user's total score" do
         Sidekiq::Testing.inline! do
           create(:address, id: 1)

--- a/spec/requests/api/visit_spec.rb
+++ b/spec/requests/api/visit_spec.rb
@@ -60,11 +60,6 @@ describe "Visit API" do
           expect(@address.reload.asked_to_leave?).to be true
         end
 
-        it "should be allowed for 'unknown'" do
-          post_visit_with_address_best_canvas_response_set_to "unknown"
-          expect(@address.reload.unknown?).to be true
-        end
-
         it "should be allowed for 'not_home'" do
           post_visit_with_address_best_canvas_response_set_to "not_home"
           expect(@address.reload.not_home?).to be true
@@ -73,6 +68,11 @@ describe "Visit API" do
         it "should be allowed for 'not_yet_visited" do
           post_visit_with_address_best_canvas_response_set_to "not_yet_visited"
           expect(@address.reload.not_yet_visited?).to be true
+        end
+
+        it "should not be allowed for 'unknown'" do
+          post_visit_with_address_best_canvas_response_set_to "unknown"
+          expect(@address.reload.unknown?).to be false
         end
 
         it "should not be allowed for 'strongly_for'" do


### PR DESCRIPTION
- [Asana task: Add "I was asked to leave" to visit endpoint](https://app.asana.com/0/60127409159606/59367029597033)
# Description

This PR enables us to set `not_home`, `unknown`, `not_yet_visited` and `asked_to_leave` values of `Address.best_canvas_response` directly through the `POST /visits` endpoint. 

It also makes it so that an `ArgumentError` will be thrown when we try to set `best_canvas_response` to any other value, as those should only be set when the visit also has people listed and those people have one of those responses.

The issue with this not working up to this point was twofold.
- The controller didn't support `best_canvas_response` as a permitted parameter, so it was being ignored - I added support for this parameter.
- There was a behavior where `best_canvas_response` was being automatically set to `:not_home`, when creating or updating an address without people - I removed this behavior. I believe `:not_home` should be explicitly set, not assumed.
# Good to discuss:
- Is `ArgumentError` good enough? This is the error that get's thrown when we try to assign a completely unlisted value to an enum, which is why I went with it. Should it be a custom error instead?
- Should there be an error at all, or should we just not update `best_canvas_response` if the value is not allowed to be set directly?
