### PR TITLE
Fix N+1 queries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,8 +28,6 @@ gem 'easypost'
 
 gem 'leaderboard'
 
-gem 'bullet'
-
 # paperclip master currently doesn't work with new version of AWS SDK
 gem 'paperclip', :git=> 'https://github.com/thoughtbot/paperclip', :ref => '523bd46c768226893f23889079a7aa9c73b57d68'
 
@@ -48,6 +46,8 @@ group :development, :test do
   gem 'pry-rails'
   gem 'pry'
   gem 'pry-nav'
+
+  gem 'bullet'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'easypost'
 
 gem 'leaderboard'
 
+gem 'bullet'
+
 # paperclip master currently doesn't work with new version of AWS SDK
 gem 'paperclip', :git=> 'https://github.com/thoughtbot/paperclip', :ref => '523bd46c768226893f23889079a7aa9c73b57d68'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,9 @@ GEM
       aws-sdk-core (= 2.1.31)
     bcrypt (3.1.10)
     builder (3.2.2)
+    bullet (4.14.10)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.9.0)
     celluloid (0.17.1.2)
       bundler
       celluloid-essentials
@@ -303,6 +306,7 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    uniform_notifier (1.9.0)
     vcr (2.9.3)
     webmock (1.21.0)
       addressable (>= 2.3.6)
@@ -314,6 +318,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers!
   aws-sdk
+  bullet
   clearance
   doorkeeper
   dotenv-rails

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -6,6 +6,7 @@ class AddressesController < ApplicationController
   def index
     if params[:radius]
       addresses = Address.within(index_params[:radius], origin: [index_params[:latitude], index_params[:longitude]])
+                         .includes([:most_supportive_resident, :people])
       render json: addresses
     else
       success, status_code, message, matched_address = GroundGame::Scenario::MatchAddress.new(search_params).call

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,9 @@ Rails.application.configure do
       secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
     }
   }
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+  end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,4 +40,11 @@ Rails.application.configure do
   Paperclip::Attachment.default_options[:path] = "#{Rails.root}/spec/test_files/:class/:id_partition/:style.:extension"
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.after_initialize do
+    #Enable bullet in your application
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.raise = true
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,6 +38,17 @@ RSpec.configure do |config|
     end
   end
 
+  if Bullet.enable?
+    config.before(:each) do
+      Bullet.start_request
+    end
+
+    config.after(:each) do
+      Bullet.perform_out_of_channel_notifications if Bullet.notification?
+      Bullet.end_request
+    end
+  end
+
   def host
     "http://api.lvh.me:3000"
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,17 +38,6 @@ RSpec.configure do |config|
     end
   end
 
-  if Bullet.enable?
-    config.before(:each) do
-      Bullet.start_request
-    end
-
-    config.after(:each) do
-      Bullet.perform_out_of_channel_notifications if Bullet.notification?
-      Bullet.end_request
-    end
-  end
-
   def host
     "http://api.lvh.me:3000"
   end


### PR DESCRIPTION
- [Asana task: Locate and fix all N+1 queries](https://app.asana.com/0/60127409159606/60649398426072)

Looks like we had it pretty good. The only cases where we had a couple of N+1 queries was `GET /address`. 

The only other place where we're working with a complex object is when creating a visit and in that case, we're returning a created record, so everything associated with it is already included.

I configured bullet so it runs during development and tests, but doesn't actually check the test code, just the actual app code. Otherwise, it would trigger warning in places where we really need an N+1 query like user following specs.
