### PR TITLE
Added validations to visit and address

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -22,6 +22,7 @@ class Address < ActiveRecord::Base
     not_home: "Not home"
   }
 
+  validates :state_code, presence: true
 
   def assign_most_supportive_resident(person)
     self.most_supportive_resident = person

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -10,6 +10,7 @@ class Visit < ActiveRecord::Base
   has_many :people, through: :person_updates
 
   validates :user, presence: true
+  validates :address_update, presence: true
 
   scope :this_week, -> { where(created_at: Time.zone.now.all_week) }
 

--- a/spec/factories/visit_factory.rb
+++ b/spec/factories/visit_factory.rb
@@ -14,9 +14,11 @@ FactoryGirl.define do
       address = create(:address)
       address_update = create(:address_update, address: address, visit: visit)
 
-      people = create_list(:person, evaluator.people_count, address: address)
-      people.each do |person|
-        create(:person_update, person: person, visit: visit)
+      if evaluator.people_count > 0
+        people = create_list(:person, evaluator.people_count, address: address)
+        people.each do |person|
+          create(:person_update, person: person, visit: visit)
+        end
       end
     end
   end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -26,6 +26,10 @@ describe Address do
     it { should belong_to(:most_supportive_resident) }
   end
 
+  context 'validations' do
+    it { should validate_presence_of(:state_code) }
+  end
+
   context 'scopes' do
     it "has a working 'within' scope" do
       first_address_in_radius = create(:address, latitude: 1, longitude: 1)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -132,6 +132,6 @@ describe User do
 
   it 'has a counter cache from visits' do
     @user = create(:user)
-    expect { @user.visits.create }.to change { @user.visits_count }.by(1)
+    expect { create(:visit, user: @user) }.to change { @user.visits_count }.by(1)
   end
 end

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -23,6 +23,7 @@ describe Visit do
 
   context 'validations' do
     it { should validate_presence_of(:user) }
+    it { should validate_presence_of(:address_update) }
   end
 
   context 'scopes' do


### PR DESCRIPTION
- [Asana task: Add validations for address and visit](https://app.asana.com/0/60127409159606/61504679960458)

Adds a `presence: true` validation to `address.state_code`, as well as one for `visit.address_update`. `address` is a `:through` association for visits, which is why I went with `address_update` instead. `address_update.address` already validates presence anyway.

I'm not sure if I should also add these requirements to the database in a migration.
