### PR TITLE
Feature/make rankings use ams

### DIFF
--- a/app/controllers/rankings_controller.rb
+++ b/app/controllers/rankings_controller.rb
@@ -14,6 +14,6 @@ class RankingsController < ApplicationController
       rankings = Ranking.for_user_in_users_friend_list(user: current_user)
     end
 
-    render json: {data: rankings}
+    render json: rankings
   end
 end

--- a/app/models/ranking.rb
+++ b/app/models/ranking.rb
@@ -19,4 +19,31 @@ class Ranking
   def self.for_friend_list(list_owner:, id:, options: DEFAULT_OPTIONS)
     UserLeaderboard.for_friend_list_of_user(list_owner).around_me(id.to_s, options)
   end
+
+  include ActiveModel::Serialization
+  # include ActiveModel::Associations
+
+  attr_accessor :score, :rank, :member, :member_data
+
+  def initialize(score: nil, rank: nil, member: nil, member_data: nil)
+    @score = score
+    @rank = rank
+    @member = member
+    @member_data = member_data
+  end
+
+  def attributes
+    {
+      'score' => score,
+      'rank' => rank
+    }
+  end
+
+  def user_id
+    @member.to_i
+  end
+
+  def user
+    @user ||= User.find(user_id)
+  end
 end

--- a/app/models/ranking.rb
+++ b/app/models/ranking.rb
@@ -21,7 +21,7 @@ class Ranking
   end
 
   include ActiveModel::Serialization
-  # include ActiveModel::Associations
+  extend ActiveModel::Naming
 
   attr_accessor :score, :rank, :member, :member_data
 
@@ -45,5 +45,9 @@ class Ranking
 
   def user
     @user ||= User.find(user_id)
+  end
+
+  def id
+    @rank
   end
 end

--- a/app/models/user_leaderboard.rb
+++ b/app/models/user_leaderboard.rb
@@ -20,6 +20,10 @@ class UserLeaderboard < Leaderboard
     rank_member(user.id.to_s, user.total_points_this_week, user.ranking_data_json)
   end
 
+  def around_me(id, options = {})
+    super(id.to_s, options).map { |rank_params| Ranking.new(rank_params) }
+  end
+
   private
 
     REDIS_OPTIONS = {

--- a/app/serializers/ranking_serializer.rb
+++ b/app/serializers/ranking_serializer.rb
@@ -1,0 +1,5 @@
+class RankingSerializer < ActiveModel::Serializer
+  attributes :id, :score, :rank
+
+  belongs_to :user
+end

--- a/spec/factories/ranking_factory.rb
+++ b/spec/factories/ranking_factory.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :ranking do |f|
+    f.score 20
+    f.rank 1
+    f.member nil
+    f.member_data nil
+  end
+end

--- a/spec/models/ranking_spec.rb
+++ b/spec/models/ranking_spec.rb
@@ -1,6 +1,29 @@
 require 'rails_helper'
 
 describe Ranking do
+
+  it "has a working model class" do
+    user = create(:user)
+    ranking = Ranking.new(member: user.id, member_data: "Something", rank: 5, score: 20)
+
+    expect(ranking.score).to eq 20
+    expect(ranking.rank).to eq 5
+    expect(ranking.member).to eq user.id
+    expect(ranking.user_id).to eq user.id
+    expect(ranking.user).to eq user
+  end
+
+  it "has a working factory" do
+    user = create(:user)
+    ranking = build(:ranking, member: user.id, member_data: "Something", rank: 5, score: 20)
+
+    expect(ranking.score).to eq 20
+    expect(ranking.rank).to eq 5
+    expect(ranking.member).to eq user.id
+    expect(ranking.user_id).to eq user.id
+    expect(ranking.user).to eq user
+  end
+
   describe ".for_everyone" do
     before do
       leaderboard = UserLeaderboard.for_everyone
@@ -9,18 +32,18 @@ describe Ranking do
         leaderboard.rank_member(index, index - 7)
       end
 
-      @user = create(:user, id: 20)
+      @user = create(:user)
       leaderboard.rank_user(@user)
     end
     it "returns a total of 11 members arround the user in the 'everyone' leaderboard" do
       ranking = Ranking.for_everyone(id: @user.id)
 
       expect(ranking.length).to eq 11
-      expect(ranking.first[:rank]).to eq 4
-      expect(ranking.last[:rank]).to eq 14
+      expect(ranking.first.rank).to eq 4
+      expect(ranking.last.rank).to eq 14
 
-      users_ranking = ranking.find { |r| r[:member] == "20" }
-      expect(users_ranking[:rank]).to eq 9
+      users_ranking = ranking.find { |r| r.user_id == @user.id }
+      expect(users_ranking.rank).to eq 9
     end
   end
 
@@ -32,7 +55,7 @@ describe Ranking do
         leaderboard.rank_member(index, index - 7)
       end
 
-      @user = create(:user, id: 20)
+      @user = create(:user)
       leaderboard.rank_user(@user)
     end
 
@@ -40,17 +63,17 @@ describe Ranking do
       ranking = Ranking.for_state(id: @user.id, state_code: "NY")
 
       expect(ranking.length).to eq 11
-      expect(ranking.first[:rank]).to eq 4
-      expect(ranking.last[:rank]).to eq 14
+      expect(ranking.first.rank).to eq 4
+      expect(ranking.last.rank).to eq 14
 
-      users_ranking = ranking.find { |r| r[:member] == "20" }
-      expect(users_ranking[:rank]).to eq 9
+      users_ranking = ranking.find { |r| r.user_id == @user.id }
+      expect(users_ranking.rank).to eq 9
     end
   end
 
   describe ".for_user_in_users_friend_list" do
     before do
-      @user = create(:user, id: 20)
+      @user = create(:user)
       leaderboard = UserLeaderboard.for_friend_list_of_user(@user)
 
       15.times do |index|
@@ -64,11 +87,11 @@ describe Ranking do
       ranking = Ranking.for_user_in_users_friend_list(user: @user)
 
       expect(ranking.length).to eq 11
-      expect(ranking.first[:rank]).to eq 4
-      expect(ranking.last[:rank]).to eq 14
+      expect(ranking.first.rank).to eq 4
+      expect(ranking.last.rank).to eq 14
 
-      users_ranking = ranking.find { |r| r[:member] == "20" }
-      expect(users_ranking[:rank]).to eq 9
+      users_ranking = ranking.find { |r| r.user_id == @user.id }
+      expect(users_ranking.rank).to eq 9
     end
   end
 
@@ -81,7 +104,7 @@ describe Ranking do
         leaderboard.rank_member(index, index - 7)
       end
 
-      @user = create(:user, id: 20)
+      @user = create(:user)
       leaderboard.rank_user(@user)
     end
 
@@ -89,11 +112,11 @@ describe Ranking do
       ranking = Ranking.for_friend_list(list_owner: @other_user, id: @user.id)
 
       expect(ranking.length).to eq 11
-      expect(ranking.first[:rank]).to eq 4
-      expect(ranking.last[:rank]).to eq 14
+      expect(ranking.first.rank).to eq 4
+      expect(ranking.last.rank).to eq 14
 
-      users_ranking = ranking.find { |r| r[:member] == "20" }
-      expect(users_ranking[:rank]).to eq 9
+      users_ranking = ranking.find { |r| r.user_id == @user.id }
+      expect(users_ranking.rank).to eq 9
     end
   end
 end

--- a/spec/models/ranking_spec.rb
+++ b/spec/models/ranking_spec.rb
@@ -24,99 +24,102 @@ describe Ranking do
     expect(ranking.user).to eq user
   end
 
-  describe ".for_everyone" do
-    before do
-      leaderboard = UserLeaderboard.for_everyone
+  describe "class methods" do
 
-      15.times do |index|
-        leaderboard.rank_member(index, index - 7)
+    describe ".for_everyone" do
+      before do
+        leaderboard = UserLeaderboard.for_everyone
+
+        15.times do |index|
+          leaderboard.rank_member(index, index - 7)
+        end
+
+        @user = create(:user)
+        leaderboard.rank_user(@user)
+      end
+      it "returns a total of 11 members arround the user in the 'everyone' leaderboard" do
+        ranking = Ranking.for_everyone(id: @user.id)
+
+        expect(ranking.length).to eq 11
+        expect(ranking.first.rank).to eq 4
+        expect(ranking.last.rank).to eq 14
+
+        users_ranking = ranking.find { |r| r.user_id == @user.id }
+        expect(users_ranking.rank).to eq 9
+      end
+    end
+
+    describe ".for_state" do
+      before do
+        leaderboard = UserLeaderboard.for_state("NY")
+
+        15.times do |index|
+          leaderboard.rank_member(index, index - 7)
+        end
+
+        @user = create(:user)
+        leaderboard.rank_user(@user)
       end
 
-      @user = create(:user)
-      leaderboard.rank_user(@user)
+      it "returns a total of 11 members arround the user in the 'state' leaderboard" do
+        ranking = Ranking.for_state(id: @user.id, state_code: "NY")
+
+        expect(ranking.length).to eq 11
+        expect(ranking.first.rank).to eq 4
+        expect(ranking.last.rank).to eq 14
+
+        users_ranking = ranking.find { |r| r.user_id == @user.id }
+        expect(users_ranking.rank).to eq 9
+      end
     end
-    it "returns a total of 11 members arround the user in the 'everyone' leaderboard" do
-      ranking = Ranking.for_everyone(id: @user.id)
 
-      expect(ranking.length).to eq 11
-      expect(ranking.first.rank).to eq 4
-      expect(ranking.last.rank).to eq 14
+    describe ".for_user_in_users_friend_list" do
+      before do
+        @user = create(:user)
+        leaderboard = UserLeaderboard.for_friend_list_of_user(@user)
 
-      users_ranking = ranking.find { |r| r.user_id == @user.id }
-      expect(users_ranking.rank).to eq 9
-    end
-  end
+        15.times do |index|
+          leaderboard.rank_member(index, index - 7)
+        end
 
-  describe ".for_state" do
-    before do
-      leaderboard = UserLeaderboard.for_state("NY")
-
-      15.times do |index|
-        leaderboard.rank_member(index, index - 7)
+        leaderboard.rank_user(@user)
       end
 
-      @user = create(:user)
-      leaderboard.rank_user(@user)
+      it "returns a total of 11 members arround the user in the user's friend list leaderboard" do
+        ranking = Ranking.for_user_in_users_friend_list(user: @user)
+
+        expect(ranking.length).to eq 11
+        expect(ranking.first.rank).to eq 4
+        expect(ranking.last.rank).to eq 14
+
+        users_ranking = ranking.find { |r| r.user_id == @user.id }
+        expect(users_ranking.rank).to eq 9
+      end
     end
 
-    it "returns a total of 11 members arround the user in the 'state' leaderboard" do
-      ranking = Ranking.for_state(id: @user.id, state_code: "NY")
+    describe ".for_friend_list" do
+      before do
+        @other_user = create(:user)
+        leaderboard = UserLeaderboard.for_friend_list_of_user(@other_user)
 
-      expect(ranking.length).to eq 11
-      expect(ranking.first.rank).to eq 4
-      expect(ranking.last.rank).to eq 14
+        15.times do |index|
+          leaderboard.rank_member(index, index - 7)
+        end
 
-      users_ranking = ranking.find { |r| r.user_id == @user.id }
-      expect(users_ranking.rank).to eq 9
-    end
-  end
-
-  describe ".for_user_in_users_friend_list" do
-    before do
-      @user = create(:user)
-      leaderboard = UserLeaderboard.for_friend_list_of_user(@user)
-
-      15.times do |index|
-        leaderboard.rank_member(index, index - 7)
+        @user = create(:user)
+        leaderboard.rank_user(@user)
       end
 
-      leaderboard.rank_user(@user)
-    end
+      it "returns a total of 11 members arround the user in another user's friend list leaderboard" do
+        ranking = Ranking.for_friend_list(list_owner: @other_user, id: @user.id)
 
-    it "returns a total of 11 members arround the user in the user's friend list leaderboard" do
-      ranking = Ranking.for_user_in_users_friend_list(user: @user)
+        expect(ranking.length).to eq 11
+        expect(ranking.first.rank).to eq 4
+        expect(ranking.last.rank).to eq 14
 
-      expect(ranking.length).to eq 11
-      expect(ranking.first.rank).to eq 4
-      expect(ranking.last.rank).to eq 14
-
-      users_ranking = ranking.find { |r| r.user_id == @user.id }
-      expect(users_ranking.rank).to eq 9
-    end
-  end
-
-  describe ".for_friend_list" do
-    before do
-      @other_user = create(:user)
-      leaderboard = UserLeaderboard.for_friend_list_of_user(@other_user)
-
-      15.times do |index|
-        leaderboard.rank_member(index, index - 7)
+        users_ranking = ranking.find { |r| r.user_id == @user.id }
+        expect(users_ranking.rank).to eq 9
       end
-
-      @user = create(:user)
-      leaderboard.rank_user(@user)
-    end
-
-    it "returns a total of 11 members arround the user in another user's friend list leaderboard" do
-      ranking = Ranking.for_friend_list(list_owner: @other_user, id: @user.id)
-
-      expect(ranking.length).to eq 11
-      expect(ranking.first.rank).to eq 4
-      expect(ranking.last.rank).to eq 14
-
-      users_ranking = ranking.find { |r| r.user_id == @user.id }
-      expect(users_ranking.rank).to eq 9
     end
   end
 end

--- a/spec/models/user_leaderboard_spec.rb
+++ b/spec/models/user_leaderboard_spec.rb
@@ -95,9 +95,9 @@ describe UserLeaderboard do
         expect(@leaderboard.total_members).to eq 1
 
         contents = @leaderboard.around_me(10)
-        expect(contents.first[:member]).to eq "10"
-        expect(contents.first[:rank]).to eq 1
-        expect(contents.first[:score]).to eq 0.0
+        expect(contents.first.user).to eq user
+        expect(contents.first.rank).to eq 1
+        expect(contents.first.score).to eq 0.0
       end
     end
 
@@ -113,9 +113,9 @@ describe UserLeaderboard do
         expect(@leaderboard.total_members).to eq 1
 
         contents = @leaderboard.around_me(10)
-        expect(contents.first[:member]).to eq "10"
-        expect(contents.first[:rank]).to eq 1
-        expect(contents.first[:score]).to eq 1000.0
+        expect(contents.first.user).to eq @user
+        expect(contents.first.rank).to eq 1
+        expect(contents.first.score).to eq 1000.0
       end
     end
   end

--- a/spec/requests/api/ranking_spec.rb
+++ b/spec/requests/api/ranking_spec.rb
@@ -9,47 +9,71 @@ describe "Rankings API" do
 
     context "when authenticated" do
 
-      let(:token) { authenticate(email: "test-user@mail.com", password: "password") }
 
       before do
-        user = create(:user, email: "test-user@mail.com", password: "password", state_code: "NY")
 
-        # I would love to somehow have this work with factory_girl or something similar, but I'm not sure how
+        @user = create(:user, email: "test-user@mail.com", password: "password", state_code: "NY", total_points: 100)
+        create(:visit, user: @user, address: create(:address))
+        @token = authenticate(email: "test-user@mail.com", password: "password")
 
         everyone = UserLeaderboard.for_everyone
-        3.times { |n| everyone.rank_member(n.to_s, n) }
-        everyone.rank_member(user.id.to_s, user.id)
+        3.times { |n| everyone.rank_user(create(:user, total_points: 0)) }
+        everyone.rank_user(@user)
 
         state_ny = UserLeaderboard.for_state("NY")
-        2.times { |n| state_ny.rank_member(n.to_s, n) }
-        state_ny.rank_member(user.id.to_s, user.id)
+        2.times { |n| state_ny.rank_user(create(:user, total_points: 0))}
+        state_ny.rank_user(@user)
 
         state_other = UserLeaderboard.for_state("OT")
-        4.times { |n| state_other.rank_member(n.to_s, n) }
-        state_other.rank_member(user.id.to_s, user.id)
+        4.times { |n| state_other.rank_user(create(:user, total_points: 0)) }
+        state_other.rank_user(@user)
 
-        friends = UserLeaderboard.for_friend_list_of_user(user)
-        6.times { |n| friends.rank_member(n.to_s, n) }
-        friends.rank_member(user.id.to_s, user.id)
+        friends = UserLeaderboard.for_friend_list_of_user(@user)
+        6.times { |n| friends.rank_user(create(:user, total_points: 0)) }
+        friends.rank_user(@user)
       end
 
       it "can return the rankings of 'everyone'" do
-        authenticated_get "rankings", { type: "everyone" }, token
+        authenticated_get "rankings", { type: "everyone" }, @token
 
         expect(last_response.status).to eq 200
         expect(json.data.length).to eq 4
+
+        first_ranking = json.data.first
+        expect(first_ranking.id).to eq "1"
+        expect(first_ranking.type).to eq "rankings"
+        expect(first_ranking.attributes.score).to eq 1000.0
+        expect(first_ranking.attributes.rank).to eq 1
+        expect(first_ranking.relationships.user.data.id).to eq @user.id.to_s
+        expect(first_ranking.relationships.user.data.type).to eq "users"
       end
       it "can return the rankings of 'state'" do
-        authenticated_get "rankings", { type: "state" }, token
+        authenticated_get "rankings", { type: "state" }, @token
 
         expect(last_response.status).to eq 200
         expect(json.data.length).to eq 3
+
+        first_ranking = json.data.first
+        expect(first_ranking.id).to eq "1"
+        expect(first_ranking.type).to eq "rankings"
+        expect(first_ranking.attributes.score).to eq 1000.0
+        expect(first_ranking.attributes.rank).to eq 1
+        expect(first_ranking.relationships.user.data.id).to eq @user.id.to_s
+        expect(first_ranking.relationships.user.data.type).to eq "users"
       end
       it "can return the rankings of 'friends'" do
-        authenticated_get "rankings", { type: "friends" }, token
+        authenticated_get "rankings", { type: "friends" }, @token
 
         expect(last_response.status).to eq 200
         expect(json.data.length).to eq 7
+
+        first_ranking = json.data.first
+        expect(first_ranking.id).to eq "1"
+        expect(first_ranking.type).to eq "rankings"
+        expect(first_ranking.attributes.score).to eq 1000.0
+        expect(first_ranking.attributes.rank).to eq 1
+        expect(first_ranking.relationships.user.data.id).to eq @user.id.to_s
+        expect(first_ranking.relationships.user.data.type).to eq "users"
       end
     end
   end

--- a/spec/requests/api/tokens_spec.rb
+++ b/spec/requests/api/tokens_spec.rb
@@ -7,7 +7,7 @@ describe "Tokens API" do
 
     context "with an email and password" do
       before do
-        create(:user, id: 10, email: 'existing-user@mail.com', password: 'test_password')
+        @user = create(:user, id: 10, email: 'existing-user@mail.com', password: 'test_password')
       end
 
       it "returns a token when both email and password are valid" do
@@ -53,7 +53,7 @@ describe "Tokens API" do
 
             rankings = Ranking.for_everyone(id: 10)
             expect(rankings.length).to eq 1
-            expect(rankings.first[:member]).to eq "10"
+            expect(rankings.first.user).to eq @user
           end
         end
 
@@ -63,7 +63,7 @@ describe "Tokens API" do
 
             rankings = Ranking.for_state(id: 10, state_code: "NY")
             expect(rankings.length).to eq 1
-            expect(rankings.first[:member]).to eq "10"
+            expect(rankings.first.user).to eq @user
           end
         end
 
@@ -73,7 +73,7 @@ describe "Tokens API" do
 
             rankings = Ranking.for_user_in_users_friend_list(user: User.find(10))
             expect(rankings.length).to eq 1
-            expect(rankings.first[:member]).to eq "10"
+            expect(rankings.first.user).to eq @user
           end
         end
       end
@@ -224,7 +224,7 @@ describe "Tokens API" do
 
               rankings = Ranking.for_everyone(id: 10)
               expect(rankings.length).to eq 1
-              expect(rankings.first[:member]).to eq "10"
+              expect(rankings.first.user).to eq @user
             end
           end
 
@@ -234,7 +234,7 @@ describe "Tokens API" do
 
               rankings = Ranking.for_user_in_users_friend_list(user: @user)
               expect(rankings.length).to eq 1
-              expect(rankings.first[:member]).to eq "10"
+              expect(rankings.first.user).to eq @user
             end
           end
 
@@ -244,7 +244,7 @@ describe "Tokens API" do
 
               rankings = Ranking.for_state(id: 10, state_code: "NY")
               expect(rankings.length).to eq 1
-              expect(rankings.first[:member]).to eq "10"
+              expect(rankings.first.user).to eq @user
             end
           end
         end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -133,7 +133,7 @@ describe "Users API" do
 
             rankings = Ranking.for_everyone(id: User.last.id)
             expect(rankings.length).to eq 1
-            expect(rankings.first[:member]).to eq User.last.id.to_s
+            expect(rankings.first.user).to eq User.last
           end
         end
 
@@ -143,7 +143,7 @@ describe "Users API" do
 
             rankings = Ranking.for_state(id: User.last.id, state_code: "NY")
             expect(rankings.length).to eq 1
-            expect(rankings.first[:member]).to eq User.last.id.to_s
+            expect(rankings.first.user).to eq User.last
           end
         end
 
@@ -153,7 +153,7 @@ describe "Users API" do
 
             rankings = Ranking.for_user_in_users_friend_list(user: User.last)
             expect(rankings.length).to eq 1
-            expect(rankings.first[:member]).to eq User.last.id.to_s
+            expect(rankings.first.user).to eq User.last
           end
         end
       end
@@ -179,7 +179,7 @@ describe "Users API" do
 
             rankings = Ranking.for_everyone(id: User.last.id)
             expect(rankings.length).to eq 1
-            expect(rankings.first[:member]).to eq User.last.id.to_s
+            expect(rankings.first.user).to eq User.last
           end
         end
 
@@ -189,7 +189,7 @@ describe "Users API" do
 
             rankings = Ranking.for_state(id: User.last.id, state_code: "NY")
             expect(rankings.length).to eq 1
-            expect(rankings.first[:member]).to eq User.last.id.to_s
+            expect(rankings.first.user).to eq User.last
           end
         end
 
@@ -199,7 +199,7 @@ describe "Users API" do
 
             rankings = Ranking.for_user_in_users_friend_list(user: User.last)
             expect(rankings.length).to eq 1
-            expect(rankings.first[:member]).to eq User.last.id.to_s
+            expect(rankings.first.user).to eq User.last
           end
         end
       end
@@ -273,7 +273,7 @@ describe "Users API" do
 
             rankings = Ranking.for_everyone(id: User.last.id)
             expect(rankings.length).to eq 1
-            expect(rankings.first[:member]).to eq User.last.id.to_s
+            expect(rankings.first.user).to eq User.last
           end
         end
 
@@ -283,7 +283,7 @@ describe "Users API" do
 
             rankings = Ranking.for_state(id: User.last.id, state_code: "NY")
             expect(rankings.length).to eq 1
-            expect(rankings.first[:member]).to eq User.last.id.to_s
+            expect(rankings.first.user).to eq User.last
           end
         end
 
@@ -293,7 +293,7 @@ describe "Users API" do
 
             rankings = Ranking.for_user_in_users_friend_list(user: User.last)
             expect(rankings.length).to eq 1
-            expect(rankings.first[:member]).to eq User.last.id.to_s
+            expect(rankings.first.user).to eq User.last
           end
         end
       end
@@ -310,7 +310,7 @@ describe "Users API" do
 
             rankings = Ranking.for_everyone(id: User.last.id)
             expect(rankings.length).to eq 1
-            expect(rankings.first[:member]).to eq User.last.id.to_s
+            expect(rankings.first.user).to eq User.last
           end
         end
 
@@ -320,7 +320,7 @@ describe "Users API" do
 
             rankings = Ranking.for_state(id: User.last.id, state_code: "NY")
             expect(rankings.length).to eq 1
-            expect(rankings.first[:member]).to eq User.last.id.to_s
+            expect(rankings.first.user).to eq User.last
           end
         end
 
@@ -330,7 +330,7 @@ describe "Users API" do
 
             rankings = Ranking.for_user_in_users_friend_list(user: User.last)
             expect(rankings.length).to eq 1
-            expect(rankings.first[:member]).to eq User.last.id.to_s
+            expect(rankings.first.user).to eq User.last
           end
         end
       end

--- a/spec/requests/api/visit_spec.rb
+++ b/spec/requests/api/visit_spec.rb
@@ -135,8 +135,8 @@ describe "Visit API" do
 
           rankings = Ranking.for_everyone(id: @user.id)
           expect(rankings.length).to eq 1
-          expect(rankings.first[:member]).to eq "11" # user id
-          expect(rankings.first[:score]).to eq 5.0 # user score
+          expect(rankings.first.user).to eq @user
+          expect(rankings.first.score).to eq 5.0
         end
       end
 
@@ -156,8 +156,8 @@ describe "Visit API" do
 
           rankings = Ranking.for_state(id: @user.id, state_code: "NY")
           expect(rankings.length).to eq 1
-          expect(rankings.first[:member]).to eq "11" # user id
-          expect(rankings.first[:score]).to eq 5.0 # user score
+          expect(rankings.first.user).to eq @user
+          expect(rankings.first.score).to eq 5.0
         end
       end
 
@@ -177,8 +177,8 @@ describe "Visit API" do
 
           rankings = Ranking.for_user_in_users_friend_list(user: @user)
           expect(rankings.length).to eq 1
-          expect(rankings.first[:member]).to eq "11" # user id
-          expect(rankings.first[:score]).to eq 5.0 # user score
+          expect(rankings.first.user).to eq @user
+          expect(rankings.first.score).to eq 5.0
         end
       end
 

--- a/spec/serializers/ranking_serializer_spec.rb
+++ b/spec/serializers/ranking_serializer_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+describe RankingSerializer, :type => :serializer do
+
+  context "individual resource representation" do
+    let(:resource) { build(:ranking, member: create(:user, id: 20).id) }
+
+    let(:serializer) { RankingSerializer.new(resource) }
+    let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer) }
+
+    context "root" do
+      subject do
+        JSON.parse(serialization.to_json)["data"]
+      end
+
+      it "has an attributes object" do
+        expect(subject["attributes"]).not_to be nil
+      end
+
+      it "has an id" do
+        expect(subject["id"]).not_to be nil
+      end
+
+      it "has a type set to 'rankings'" do
+        expect(subject["type"]).to eq "rankings"
+      end
+    end
+
+    context "attributes" do
+
+      subject do
+        JSON.parse(serialization.to_json)["data"]["attributes"]
+      end
+
+      it "has a 'score'" do
+        expect(subject["score"]).to eql(resource.score)
+      end
+
+      it "has a 'rank'" do
+        expect(subject["rank"]).to eql(resource.rank)
+      end
+    end
+
+    context "relationships" do
+      subject do
+        JSON.parse(serialization.to_json)["data"]["relationships"]
+      end
+
+      it "should include a 'user' relationship" do
+        expect(subject["user"]).not_to be_nil
+        expect(subject["user"]["data"]["id"]).to eq resource.user_id.to_s
+      end
+    end
+
+    context "included" do
+      subject do
+        JSON.parse(serialization.to_json)["included"]
+      end
+
+      it "should be empty" do
+        expect(subject).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [Asana task: Make API rankings work using AMS](https://app.asana.com/0/52390949460913/62938112206522)
# Description

I could push this a couple of steps further, but it serves our purposes for now.

With these changes in place, rankings are compatible with AMS and can be serialized using `render json` in our controllers. They also include a user relationship, which is also serialized in the standard format.

The changes required including `ActiveModel:Serialization` and extending `ActiveModel:Naming`. To extend, I had to define an `id` method on the model, which, for now, simply returns the rank. Since we aren't creating records, really, it doesn't matter that there may and will be the same rank for different leaderboards.

This whole thing could be further extended with several things.
- It should be possible to include the whole user record with a ranking payload.
- We're just storing the member_data hash for now. If we agree on what it contains, I could easily create methods parsing it, which would then allow us to serialize that information a fell.
- We could work it out so each ranking also has a type associated, so we know which leaderboard it comes from. This could be useful on the ember side, but I'm not sure yet.
- We could make the `#initialize method private` and add a new method along the lines of `#for_user` or `#from_data`. It wouldn't help us in the functionality department, but it may make the code more explicit/understandable/readable.

However, none of that is really necessary for us right now. I believe this is mergeable as is. The format the rankings api will now return is:

``` JavaScript
[{
  id: <rank>,
  type: "rankings",
  attributes: {
    score: <score>,
    rank: <rank>
  },
  relationships: {
    user: { data: { type: "users", id: <user_id> } }
  }
}, ...]
```
