### PR TITLE
Add 'email',  'phone' and 'preferred_contact_method' to people

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'leaderboard'
 
 gem 'parse-ruby-client'
 
+gem 'phonelib'
+
 # paperclip master currently doesn't work with new version of AWS SDK
 gem 'paperclip', :git=> 'https://github.com/thoughtbot/paperclip', :ref => '523bd46c768226893f23889079a7aa9c73b57d68'
 

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'leaderboard'
 gem 'parse-ruby-client'
 
 gem 'phonelib'
+gem 'email_validator'
 
 # paperclip master currently doesn't work with new version of AWS SDK
 gem 'paperclip', :git=> 'https://github.com/thoughtbot/paperclip', :ref => '523bd46c768226893f23889079a7aa9c73b57d68'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,6 +307,7 @@ DEPENDENCIES
   doorkeeper
   dotenv-rails
   easypost
+  email_validator
   factory_girl_rails
   faker
   fakeredis

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,8 +77,7 @@ GEM
     bullet (4.14.10)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.9.0)
-    celluloid (0.17.1.2)
-      bundler
+    celluloid (0.17.2)
       celluloid-essentials
       celluloid-extras
       celluloid-fsm
@@ -182,6 +181,7 @@ GEM
       faraday
       faraday_middleware
     pg (0.18.3)
+    phonelib (0.5.4)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -318,6 +318,7 @@ DEPENDENCIES
   paperclip!
   parse-ruby-client
   pg
+  phonelib
   pry
   pry-nav
   pry-rails

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,6 +1,7 @@
 class Person < ActiveRecord::Base
   belongs_to :address
   validates :phone, phone: { possible: true, allow_blank: true }
+  validates :email, email: true, allow_blank: true
 
   enum canvas_response: {
     unknown: "Unknown",

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,5 +1,6 @@
 class Person < ActiveRecord::Base
   belongs_to :address
+  validates :phone, phone: { possible: true, allow_blank: true }
 
   enum canvas_response: {
     unknown: "Unknown",

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -19,6 +19,11 @@ class Person < ActiveRecord::Base
     independent_affiliation: "Independent"
   }
 
+  enum preferred_contact_method: {
+    contact_by_phone: "phone",
+    contact_by_email: "email"
+  }
+
   def canvas_response_rating
     if asked_to_leave?
       return -1
@@ -47,6 +52,7 @@ class Person < ActiveRecord::Base
     else
       person = Person.new(params)
     end
+
     person
   end
 end

--- a/app/serializers/person_serializer.rb
+++ b/app/serializers/person_serializer.rb
@@ -1,5 +1,7 @@
 class PersonSerializer < ActiveModel::Serializer
-  attributes :id, :first_name, :last_name, :party_affiliation, :canvas_response
+  attributes :id, :first_name, :last_name,
+    :party_affiliation, :canvas_response,
+    :phone, :email, :preferred_contact_method
 
   belongs_to :address
 end

--- a/config/initializers/phonelib.rb
+++ b/config/initializers/phonelib.rb
@@ -1,0 +1,1 @@
+Phonelib.default_country = 'US'

--- a/db/migrate/20151105091038_add_email_phone_preferred_contact_method_to_people.rb
+++ b/db/migrate/20151105091038_add_email_phone_preferred_contact_method_to_people.rb
@@ -1,0 +1,7 @@
+class AddEmailPhonePreferredContactMethodToPeople < ActiveRecord::Migration
+  def change
+    add_column :people, :email, :string
+    add_column :people, :phone, :string
+    add_column :people, :preferred_contact_method, :string, default: "email"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151030223715) do
+ActiveRecord::Schema.define(version: 20151105091038) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,11 +95,14 @@ ActiveRecord::Schema.define(version: 20151030223715) do
   create_table "people", force: :cascade do |t|
     t.string   "first_name"
     t.string   "last_name"
-    t.string   "canvas_response",   default: "Unknown"
-    t.string   "party_affiliation", default: "Unknown"
+    t.string   "canvas_response",          default: "Unknown"
+    t.string   "party_affiliation",        default: "Unknown"
     t.integer  "address_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "email"
+    t.string   "phone"
+    t.string   "preferred_contact_method", default: "email"
   end
 
   create_table "person_updates", force: :cascade do |t|

--- a/spec/lib/ground_game/scenario/create_visit_spec.rb
+++ b/spec/lib/ground_game/scenario/create_visit_spec.rb
@@ -55,7 +55,7 @@ module GroundGame
             expect(visit.total_points).not_to be_nil
           end
 
-          it "updates the user's state code" do
+          it "updates the user's state code to the address state code" do
             user = create(:user, email: "josh@cookacademy.com", state_code: "MD")
 
             address = create(:address, id: 1, state_code: "CA")

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -67,13 +67,13 @@ describe Person do
   it "has a working 'preferred_contact_method' enum" do
     person = create(:person)
 
-    expect(person.contact_by_phone?).to be true
-
-    person.contact_by_email!
     expect(person.contact_by_email?).to be true
 
     person.contact_by_phone!
     expect(person.contact_by_phone?).to be true
+
+    person.contact_by_email!
+    expect(person.contact_by_email?).to be true
   end
 
   describe "instance methods" do
@@ -125,7 +125,7 @@ describe Person do
         first_name: "John",
         last_name: "Doe",
         email: "john@doe.com",
-        phone: "12456",
+        phone: "12345",
         party_affiliation: :democrat_affiliation,
         canvas_response: :strongly_for,
         preferred_contact_method: :contact_by_phone
@@ -156,8 +156,8 @@ describe Person do
         first_name: "John",
         last_name: "Doe",
         email: "john@doe.com",
-        phone: "12456",
-        party_affiliation: "democrat",
+        phone: "12345",
+        party_affiliation: "Democrat",
         canvas_response: "strongly_for",
         preferred_contact_method: "phone"
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -22,6 +22,39 @@ describe Person do
     it { should belong_to(:address) }
   end
 
+  context 'validations' do
+    describe 'phone validations' do
+      before(:each) do
+        @person = create(:person)
+      end
+
+      it 'should accept a 11 digit number that looks like a phone without hyphens' do
+        @person.phone = '5555551212'
+        expect(@person).to be_valid
+      end
+
+      it 'should accept a 11 digit number that looks like a phone with hyphens' do
+        @person.phone = '555-555-1212'
+        expect(@person).to be_valid
+      end
+
+      it 'should not accept a phone number without an area code' do
+        @person.phone = '5551212'
+        expect(@person).to_not be_valid
+      end
+
+      it 'should not accept a random digit string as a phone' do
+        @person.phone = '12345'
+        expect(@person).to_not be_valid
+      end
+
+      it 'should not accept alphas as a phone' do
+        @person.phone = 'abc-abc-abcd'
+        expect(@person).to_not be_valid
+      end
+    end
+  end
+
   it "has a working 'canvas_response' enum" do
     person = create(:person)
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -23,11 +23,10 @@ describe Person do
   end
 
   context 'validations' do
+    before(:each) do
+      @person = create(:person)
+    end
     describe 'phone validations' do
-      before(:each) do
-        @person = create(:person)
-      end
-
       it 'should accept a 11 digit number that looks like a phone without hyphens' do
         @person.phone = '5555551212'
         expect(@person).to be_valid
@@ -50,6 +49,24 @@ describe Person do
 
       it 'should not accept alphas as a phone' do
         @person.phone = 'abc-abc-abcd'
+        expect(@person).to_not be_valid
+      end
+    end
+
+    describe 'email validations' do
+      it 'should accept a valid email' do
+        @person.email = 'juan@example.com'
+        expect(@person).to be_valid
+      end
+
+      it 'should not accept a invalid email' do
+        @person.email = 'juan@example'
+        expect(@person).to_not be_valid
+        @person.email = 'juan'
+        expect(@person).to_not be_valid
+        @person.email = 'example.com'
+        expect(@person).to_not be_valid
+        @person.email = 'juan@example.com123'
         expect(@person).to_not be_valid
       end
     end

--- a/spec/requests/api/visit_spec.rb
+++ b/spec/requests/api/visit_spec.rb
@@ -14,30 +14,447 @@ describe "Visit API" do
         @user = create(:user, id: 11, email: "test-user@mail.com", password: "password", state_code: "NY")
       end
 
-      it "should return the created visit, with score included" do
-        create(:address, id: 1)
+      context "when it succeeds creating the visit" do
+        it "should return the created visit, with score included" do
+          create(:address, id: 1)
 
-        authenticated_post "visits", {
-          data: {
-            attributes: { duration_sec: 200 },
-            relationships: { address: { data: { id: 1, type: "addresses" } } }
-          },
-          included: [ { id: 1, type: "addresses" } ]
-        }, token
+          authenticated_post "visits", {
+            data: {
+              attributes: { duration_sec: 200 },
+              relationships: { address: { data: { id: 1, type: "addresses" } } }
+            },
+            included: [ { id: 1, type: "addresses" } ]
+          }, token
 
-        expect(last_response.status).to eq 200
+          expect(last_response.status).to eq 200
 
-        visit_json = json.data.attributes
+          visit_json = json.data.attributes
 
-        expect(visit_json.duration_sec).to eq 200
-        expect(visit_json.total_points).not_to be_nil
+          expect(visit_json.duration_sec).to eq 200
+          expect(visit_json.total_points).not_to be_nil
 
-        included_json = json.included
-        scores_json = included_json.select { |include| include.type == "scores" }
-        expect(scores_json.length).to eq 1
-        score_json = scores_json.first.attributes
-        expect(score_json.points_for_updates).to eq 0
-        expect(score_json.points_for_knock).to eq 5
+          included_json = json.included
+          scores_json = included_json.select { |include| include.type == "scores" }
+          expect(scores_json.length).to eq 1
+          score_json = scores_json.first.attributes
+          expect(score_json.points_for_updates).to eq 0
+          expect(score_json.points_for_knock).to eq 5
+        end
+
+        it "should update the user's total score" do
+          Sidekiq::Testing.inline! do
+            create(:address, id: 1)
+
+            expect(@user.total_points).to eq 0
+
+            authenticated_post "visits", {
+              data: {
+                attributes: { duration_sec: 200 },
+                relationships: { address: { data: { id: 1, type: "addresses" } } }
+              },
+              included: [ { id: 1, type: "addresses" } ]
+            }, token
+
+            expect(@user.reload.total_points).to eq 5
+          end
+        end
+
+        it "should update the 'everyone' leaderboard" do
+          Sidekiq::Testing.inline! do
+            create(:address, id: 1)
+
+            expect(@user.total_points).to eq 0
+
+            authenticated_post "visits", {
+              data: {
+                attributes: { duration_sec: 200 },
+                relationships: { address: { data: { id: 1, type: "addresses" } } }
+              },
+              included: [ { id: 1, type: "addresses" } ]
+            }, token
+
+            rankings = Ranking.for_everyone(id: @user.id)
+            expect(rankings.length).to eq 1
+            expect(rankings.first.user).to eq @user
+            expect(rankings.first.score).to eq 5.0
+          end
+        end
+
+        it "should update the 'state' leaderboard" do
+          Sidekiq::Testing.inline! do
+            create(:address, id: 1)
+
+            expect(@user.total_points).to eq 0
+
+            authenticated_post "visits", {
+              data: {
+                attributes: { duration_sec: 200 },
+                relationships: { address: { data: { id: 1, type: "addresses" } } }
+              },
+              included: [ { id: 1, type: "addresses" } ]
+            }, token
+
+            rankings = Ranking.for_state(id: @user.id, state_code: "NY")
+            expect(rankings.length).to eq 1
+            expect(rankings.first.user).to eq @user
+            expect(rankings.first.score).to eq 5.0
+          end
+        end
+
+        it "should update the 'friends' leaderboard" do
+          Sidekiq::Testing.inline! do
+            create(:address, id: 1)
+
+            expect(@user.total_points).to eq 0
+
+            authenticated_post "visits", {
+              data: {
+                attributes: { duration_sec: 200 },
+                relationships: { address: { data: { id: 1, type: "addresses" } } }
+              },
+              included: [ { id: 1, type: "addresses" } ]
+            }, token
+
+            rankings = Ranking.for_user_in_users_friend_list(user: @user)
+            expect(rankings.length).to eq 1
+            expect(rankings.first.user).to eq @user
+            expect(rankings.first.score).to eq 5.0
+          end
+        end
+
+        context "when address exists" do
+
+          context "when person already exists" do
+
+            it "creates a visit, updates the address and the person" do
+              address = create(:address, id: 1)
+              create(:person, id: 10, address: address, canvas_response: :unknown, party_affiliation: :unknown_affiliation)
+
+              authenticated_post "visits", {
+                data: {
+                  attributes: { duration_sec: 200 },
+                  relationships: {
+                    address: { data: { id: 1, type: "addresses" } },
+                    person: { data: { id: 10, type: "people" } }
+                  }
+                },
+                included: [
+                  {
+                    type: "addresses",
+                    id: 1,
+                    attributes: {
+                      latitude: 2.0,
+                      longitude: 3.0,
+                      city: "New York",
+                      state_code: "NY",
+                      zip_code: "12345",
+                      street_1: "Test street",
+                      street_2: "Additional data"
+                    }
+                  },
+                  {
+                    type: "people",
+                    id: 10,
+                    attributes: {
+                      first_name: "John",
+                      last_name: "Doe",
+                      canvas_response: "leaning_for",
+                      party_affiliation: "Democrat",
+                      email: "john@doe.com",
+                      phone: "12345",
+                      preferred_contact_method: "phone"
+                    }
+                  }
+                ]
+              }, token
+
+              expect(last_response.status).to eq 200
+
+              expect(Person.count).to eq 1
+              expect(Address.count).to eq 1
+
+              modified_address = Address.find(1)
+              expect(modified_address.latitude).to eq 2.0
+              expect(modified_address.longitude).to eq 3.0
+              expect(modified_address.city).to eq "New York"
+              expect(modified_address.state_code).to eq "NY"
+              expect(modified_address.zip_code).to eq "12345"
+              expect(modified_address.street_1).to eq "Test street"
+              expect(modified_address.street_2).to eq "Additional data"
+
+              modified_person = Person.find(10)
+              expect(modified_person.first_name).to eq "John"
+              expect(modified_person.last_name).to eq "Doe"
+              expect(modified_person.leaning_for?).to be true
+              expect(modified_person.democrat_affiliation?).to be true
+              expect(modified_person.email).to eq "john@doe.com"
+              expect(modified_person.phone).to eq "12345"
+              expect(modified_person.contact_by_phone?).to be true
+
+              expect(modified_person.address).to eq modified_address
+              expect(modified_address.most_supportive_resident).to eq modified_person
+              expect(modified_address.best_canvas_response).to eq modified_person.canvas_response
+            end
+          end
+
+          context "when person does not exist" do
+
+            it "creates a visit, updates the address, creates the person" do
+
+              address = create(:address, id: 1)
+
+              authenticated_post "visits", {
+                data: {
+                  attributes: { duration_sec: 200 },
+                  relationships: {
+                    address: { data: { id: 1, type: "addresses" } },
+                    person: { data: { id: 10, type: "people" } }
+                  }
+                },
+                included: [
+                  {
+                    type: "addresses",
+                    id: 1,
+                    attributes: {
+                      latitude: 2.0,
+                      longitude: 3.0,
+                      city: "New York",
+                      state_code: "NY",
+                      zip_code: "12345",
+                      street_1: "Test street",
+                      street_2: "Additional data"
+                    }
+                  },
+                  {
+                    type: "people",
+                    attributes: {
+                      first_name: "John",
+                      last_name: "Doe",
+                      canvas_response: "leaning_for",
+                      party_affiliation: "Democrat",
+                      email: "john@doe.com",
+                      phone: "12345",
+                      preferred_contact_method: "phone"
+                    }
+                  }
+                ]
+              }, token
+
+              expect(last_response.status).to eq 200
+              expect(json.data.relationships.people.length).to eq 1
+
+              expect(Person.count).to eq 1
+              expect(Address.count).to eq 1
+
+              modified_address = Address.find(1)
+              expect(modified_address.latitude).to eq 2.0
+              expect(modified_address.longitude).to eq 3.0
+              expect(modified_address.city).to eq "New York"
+              expect(modified_address.state_code).to eq "NY"
+              expect(modified_address.zip_code).to eq "12345"
+              expect(modified_address.street_1).to eq "Test street"
+              expect(modified_address.street_2).to eq "Additional data"
+
+              new_person = Person.last
+              expect(new_person.first_name).to eq "John"
+              expect(new_person.last_name).to eq "Doe"
+              expect(new_person.leaning_for?).to be true
+              expect(new_person.democrat_affiliation?).to be true
+              expect(new_person.email).to eq "john@doe.com"
+              expect(new_person.phone).to eq "12345"
+              expect(new_person.contact_by_phone?).to be true
+
+              expect(new_person.address).to eq modified_address
+              expect(modified_address.most_supportive_resident).to eq new_person
+              expect(modified_address.best_canvas_response).to eq new_person.canvas_response
+            end
+          end
+
+          context "when some people exist, some don't" do
+
+            it "creates a visit, updates the address, creates people that don't exist, updates people that do" do
+              address = create(:address, id: 1)
+              create(:person, id: 10, address: address, canvas_response: :unknown, party_affiliation: :unknown_affiliation)
+
+              authenticated_post "visits", {
+                data: {
+                  attributes: { duration_sec: 200 },
+                  relationships: {
+                    address: { data: { id: 1, type: "addresses" } },
+                    person: { data: { id: 10, type: "people" } }
+                  }
+                },
+                included: [
+                  {
+                    type: "addresses",
+                    id: 1,
+                    attributes: {
+                      latitude: 2.0,
+                      longitude: 3.0,
+                      city: "New York",
+                      state_code: "NY",
+                      zip_code: "12345",
+                      street_1: "Test street",
+                      street_2: "Additional data"
+                    }
+                  },
+                  {
+                    type: "people",
+                    id: 10,
+                    attributes: {
+                      first_name: "John",
+                      last_name: "Doe",
+                      canvas_response: "leaning_for",
+                      party_affiliation: "Democrat",
+                      email: "john@doe.com",
+                      phone:"12345",
+                      preferred_contact_method: "phone"
+                    }
+                  },
+                  {
+                    type: "people",
+                    attributes: {
+                      first_name: "Jane",
+                      last_name: "Doe",
+                      canvas_response: "strongly_for",
+                      party_affiliation: "Republican",
+                      email: "jane@doe.com",
+                      phone: "54321",
+                      preferred_contact_method: "email"
+                    }
+                  }
+                ]
+              }, token
+
+              expect(last_response.status).to eq 200
+
+              expect(Person.count).to eq 2
+              expect(Address.count).to eq 1
+
+              modified_address = Address.find(1)
+              expect(modified_address.latitude).to eq 2.0
+              expect(modified_address.longitude).to eq 3.0
+              expect(modified_address.city).to eq "New York"
+              expect(modified_address.state_code).to eq "NY"
+              expect(modified_address.zip_code).to eq "12345"
+              expect(modified_address.street_1).to eq "Test street"
+              expect(modified_address.street_2).to eq "Additional data"
+
+              modified_person = Person.find(10)
+              expect(modified_person.first_name).to eq "John"
+              expect(modified_person.last_name).to eq "Doe"
+              expect(modified_person.leaning_for?).to be true
+              expect(modified_person.democrat_affiliation?).to be true
+              expect(modified_person.email).to eq "john@doe.com"
+              expect(modified_person.phone).to eq "12345"
+              expect(modified_person.contact_by_phone?).to be true
+
+              new_person = Person.find_by(first_name: "Jane")
+              expect(new_person).to be_persisted
+              expect(new_person.last_name).to eq "Doe"
+              expect(new_person.strongly_for?).to be true
+              expect(new_person.republican_affiliation?).to be true
+              expect(new_person.email).to eq "jane@doe.com"
+              expect(new_person.phone).to eq "54321"
+              expect(new_person.contact_by_email?).to be true
+
+              expect(modified_person.address).to eq modified_address
+              expect(new_person.address).to eq modified_address
+              expect(modified_address.most_supportive_resident).to eq new_person
+              expect(modified_address.best_canvas_response).to eq new_person.canvas_response
+            end
+          end
+        end
+
+        context "when address doesn\'t exist" do
+
+          it "creates the visit, the address and the people", vcr: { cassette_name: "requests/api/visits/create_visit/creates_the_visit_the_addres_and_the_people" }  do
+            authenticated_post "visits", {
+              data: {
+                attributes: { duration_sec: 200 }
+              },
+              included: [
+                {
+                  type: "addresses",
+                  attributes: {
+                    latitude: 40.771913,
+                    longitude: -73.9673735,
+                    street_1: "5th Avenue",
+                    city: "New York",
+                    state_code: "NY"
+                  }
+                },
+                {
+                  type: "people",
+                  attributes: {
+                    first_name: "John",
+                    last_name: "Doe",
+                    canvas_response: "leaning_for",
+                    party_affiliation: "Democrat",
+                    email: "john@doe.com",
+                    phone: "12345",
+                    preferred_contact_method: "phone"
+                  }
+                }
+              ]
+            }, token
+
+            expect(last_response.status).to eq 200
+
+            expect(Person.count).to eq 1
+            expect(Address.count).to eq 1
+
+
+            new_address = Address.last
+            # basic fields
+            expect(new_address.latitude).to eq 40.771913
+            expect(new_address.longitude).to eq -73.9673735
+            expect(new_address.street_1)
+            expect(new_address.city).to eq "New York"
+            expect(new_address.street_1).to eq "5th Avenue"
+            expect(new_address.state_code).to eq "NY"
+            # USPS verified fields
+            expect(new_address.usps_verified_street_1).to eq "5 AVENUE A"
+            expect(new_address.usps_verified_street_2).to eq ""
+            expect(new_address.usps_verified_city).to eq "NEW YORK"
+            expect(new_address.usps_verified_state).to eq "NY"
+            expect(new_address.usps_verified_zip).to eq "10009-7944"
+
+            new_person = Person.last
+            expect(new_person.first_name).to eq "John"
+            expect(new_person.last_name).to eq "Doe"
+            expect(new_person.leaning_for?).to be true
+            expect(new_person.democrat_affiliation?).to be true
+            expect(new_person.email).to eq "john@doe.com"
+            expect(new_person.phone).to eq "12345"
+            expect(new_person.contact_by_phone?).to be true
+
+            expect(new_person.address).to eq new_address
+            expect(new_address.most_supportive_resident).to eq new_person
+            expect(new_address.best_canvas_response).to eq new_person.canvas_response
+          end
+        end
+      end
+
+      context "when it fails creating the visit" do
+        it "should return an error response" do
+          address = create(:address, id: 1)
+
+          authenticated_post "visits", {
+            data: {
+              attributes: { duration_sec: 200 },
+              relationships: { address: { data: { id: 1, type: "addresses" } }, person: { data: { id: 10, type: "people" } } }
+            },
+            included: [ { type: "addresses", id: 1, attributes: { } }, { type: "people", id: 10, attributes: {} } ]
+          }, token
+          expect(last_response.status).to eq 404
+          expect(json.errors.length).to eq 1
+          error = json.errors.first
+          expect(error.id).to eq "RECORD_NOT_FOUND"
+          expect(error.title).to eq "Record not found"
+          expect(error.detail).to eq "Couldn't find Person with 'id'=10"
+          expect(error.status).to eq 404
+        end
       end
 
       describe "setting 'address.best_canvas_response' directly" do
@@ -98,391 +515,6 @@ describe "Visit API" do
         it "should not be allowed for 'strongly_against'" do
           post_visit_with_address_best_canvas_response_set_to "strongly_against"
           expect(@address.reload.strongly_against?).to be false
-        end
-      end
-
-      it "should update the user's total score" do
-        Sidekiq::Testing.inline! do
-          create(:address, id: 1)
-
-          expect(@user.total_points).to eq 0
-
-          authenticated_post "visits", {
-            data: {
-              attributes: { duration_sec: 200 },
-              relationships: { address: { data: { id: 1, type: "addresses" } } }
-            },
-            included: [ { id: 1, type: "addresses" } ]
-          }, token
-
-          expect(@user.reload.total_points).to eq 5
-        end
-      end
-
-      it "should update the 'everyone' leaderboard" do
-        Sidekiq::Testing.inline! do
-          create(:address, id: 1)
-
-          expect(@user.total_points).to eq 0
-
-          authenticated_post "visits", {
-            data: {
-              attributes: { duration_sec: 200 },
-              relationships: { address: { data: { id: 1, type: "addresses" } } }
-            },
-            included: [ { id: 1, type: "addresses" } ]
-          }, token
-
-          rankings = Ranking.for_everyone(id: @user.id)
-          expect(rankings.length).to eq 1
-          expect(rankings.first.user).to eq @user
-          expect(rankings.first.score).to eq 5.0
-        end
-      end
-
-      it "should update the 'state' leaderboard" do
-        Sidekiq::Testing.inline! do
-          create(:address, id: 1)
-
-          expect(@user.total_points).to eq 0
-
-          authenticated_post "visits", {
-            data: {
-              attributes: { duration_sec: 200 },
-              relationships: { address: { data: { id: 1, type: "addresses" } } }
-            },
-            included: [ { id: 1, type: "addresses" } ]
-          }, token
-
-          rankings = Ranking.for_state(id: @user.id, state_code: "NY")
-          expect(rankings.length).to eq 1
-          expect(rankings.first.user).to eq @user
-          expect(rankings.first.score).to eq 5.0
-        end
-      end
-
-      it "should update the 'friends' leaderboard" do
-        Sidekiq::Testing.inline! do
-          create(:address, id: 1)
-
-          expect(@user.total_points).to eq 0
-
-          authenticated_post "visits", {
-            data: {
-              attributes: { duration_sec: 200 },
-              relationships: { address: { data: { id: 1, type: "addresses" } } }
-            },
-            included: [ { id: 1, type: "addresses" } ]
-          }, token
-
-          rankings = Ranking.for_user_in_users_friend_list(user: @user)
-          expect(rankings.length).to eq 1
-          expect(rankings.first.user).to eq @user
-          expect(rankings.first.score).to eq 5.0
-        end
-      end
-
-      context "when address exists" do
-
-        context "when person already exists" do
-
-          it "creates a visit, updates the address and the person" do
-            address = create(:address, id: 1)
-            create(:person, id: 10, address: address, canvas_response: :unknown, party_affiliation: :unknown_affiliation)
-
-            authenticated_post "visits", {
-              data: {
-                attributes: { duration_sec: 200 },
-                relationships: {
-                  address: { data: { id: 1, type: "addresses" } },
-                  person: { data: { id: 10, type: "people" } }
-                }
-              },
-              included: [
-                {
-                  type: "addresses",
-                  id: 1,
-                  attributes: {
-                    latitude: 2.0,
-                    longitude: 3.0,
-                    city: "New York",
-                    state_code: "NY",
-                    zip_code: "12345",
-                    street_1: "Test street",
-                    street_2: "Additional data"
-                  }
-                },
-                {
-                  type: "people",
-                  id: 10,
-                  attributes: {
-                    first_name: "John",
-                    last_name: "Doe",
-                    canvas_response: "leaning_for",
-                    party_affiliation: "Democrat"
-                  }
-                }
-              ]
-            }, token
-
-            expect(last_response.status).to eq 200
-
-            expect(Person.count).to eq 1
-            expect(Address.count).to eq 1
-
-            modified_address = Address.find(1)
-            expect(modified_address.latitude).to eq 2.0
-            expect(modified_address.longitude).to eq 3.0
-            expect(modified_address.city).to eq "New York"
-            expect(modified_address.state_code).to eq "NY"
-            expect(modified_address.zip_code).to eq "12345"
-            expect(modified_address.street_1).to eq "Test street"
-            expect(modified_address.street_2).to eq "Additional data"
-
-            modified_person = Person.find(10)
-            expect(modified_person.first_name).to eq "John"
-            expect(modified_person.last_name).to eq "Doe"
-            expect(modified_person.leaning_for?).to be true
-            expect(modified_person.democrat_affiliation?).to be true
-
-            expect(modified_person.address).to eq modified_address
-            expect(modified_address.most_supportive_resident).to eq modified_person
-            expect(modified_address.best_canvas_response).to eq modified_person.canvas_response
-          end
-        end
-
-        context "when person does not exist" do
-
-          it "creates a visit, updates the address, creates the person" do
-
-            address = create(:address, id: 1)
-
-            authenticated_post "visits", {
-              data: {
-                attributes: { duration_sec: 200 },
-                relationships: {
-                  address: { data: { id: 1, type: "addresses" } },
-                  person: { data: { id: 10, type: "people" } }
-                }
-              },
-              included: [
-                {
-                  type: "addresses",
-                  id: 1,
-                  attributes: {
-                    latitude: 2.0,
-                    longitude: 3.0,
-                    city: "New York",
-                    state_code: "NY",
-                    zip_code: "12345",
-                    street_1: "Test street",
-                    street_2: "Additional data"
-                  }
-                },
-                {
-                  type: "people",
-                  attributes: {
-                    first_name: "John",
-                    last_name: "Doe",
-                    canvas_response: "leaning_for",
-                    party_affiliation: "Democrat"
-                  }
-                }
-              ]
-            }, token
-
-            expect(last_response.status).to eq 200
-            expect(json.data.relationships.people.length).to eq 1
-
-            expect(Person.count).to eq 1
-            expect(Address.count).to eq 1
-
-            modified_address = Address.find(1)
-            expect(modified_address.latitude).to eq 2.0
-            expect(modified_address.longitude).to eq 3.0
-            expect(modified_address.city).to eq "New York"
-            expect(modified_address.state_code).to eq "NY"
-            expect(modified_address.zip_code).to eq "12345"
-            expect(modified_address.street_1).to eq "Test street"
-            expect(modified_address.street_2).to eq "Additional data"
-
-            new_person = Person.last
-            expect(new_person.first_name).to eq "John"
-            expect(new_person.last_name).to eq "Doe"
-            expect(new_person.leaning_for?).to be true
-            expect(new_person.democrat_affiliation?).to be true
-
-            expect(new_person.address).to eq modified_address
-            expect(modified_address.most_supportive_resident).to eq new_person
-            expect(modified_address.best_canvas_response).to eq new_person.canvas_response
-          end
-        end
-
-        context "when some people exist, some don't" do
-
-          it "creates a visit, updates the address, creates people that don't exist, updates people that do" do
-            address = create(:address, id: 1)
-            create(:person, id: 10, address: address, canvas_response: :unknown, party_affiliation: :unknown_affiliation)
-
-            authenticated_post "visits", {
-              data: {
-                attributes: { duration_sec: 200 },
-                relationships: {
-                  address: { data: { id: 1, type: "addresses" } },
-                  person: { data: { id: 10, type: "people" } }
-                }
-              },
-              included: [
-                {
-                  type: "addresses",
-                  id: 1,
-                  attributes: {
-                    latitude: 2.0,
-                    longitude: 3.0,
-                    city: "New York",
-                    state_code: "NY",
-                    zip_code: "12345",
-                    street_1: "Test street",
-                    street_2: "Additional data"
-                  }
-                },
-                {
-                  type: "people",
-                  id: 10,
-                  attributes: {
-                    first_name: "John",
-                    last_name: "Doe",
-                    canvas_response: "leaning_for",
-                    party_affiliation: "Democrat"
-                  }
-                },
-                {
-                  type: "people",
-                  attributes: {
-                    first_name: "Jane",
-                    last_name: "Doe",
-                    canvas_response: "strongly_for",
-                    party_affiliation: "Republican"
-                  }
-                }
-              ]
-            }, token
-
-            expect(last_response.status).to eq 200
-
-            expect(Person.count).to eq 2
-            expect(Address.count).to eq 1
-
-            modified_address = Address.find(1)
-            expect(modified_address.latitude).to eq 2.0
-            expect(modified_address.longitude).to eq 3.0
-            expect(modified_address.city).to eq "New York"
-            expect(modified_address.state_code).to eq "NY"
-            expect(modified_address.zip_code).to eq "12345"
-            expect(modified_address.street_1).to eq "Test street"
-            expect(modified_address.street_2).to eq "Additional data"
-
-            modified_person = Person.find(10)
-            expect(modified_person.first_name).to eq "John"
-            expect(modified_person.last_name).to eq "Doe"
-            expect(modified_person.leaning_for?).to be true
-            expect(modified_person.democrat_affiliation?).to be true
-
-            new_person = Person.find_by(first_name: "Jane")
-            expect(new_person).to be_persisted
-            expect(new_person.last_name).to eq "Doe"
-            expect(new_person.strongly_for?).to be true
-            expect(new_person.republican_affiliation?).to be true
-
-            expect(modified_person.address).to eq modified_address
-            expect(new_person.address).to eq modified_address
-            expect(modified_address.most_supportive_resident).to eq new_person
-            expect(modified_address.best_canvas_response).to eq new_person.canvas_response
-          end
-        end
-      end
-
-      context "when address doesn\'t exist" do
-
-        it "creates the visit, the address and the people", vcr: { cassette_name: "requests/api/visits/create_visit/creates_the_visit_the_addres_and_the_people" }  do
-          authenticated_post "visits", {
-            data: {
-              attributes: { duration_sec: 200 }
-            },
-            included: [
-              {
-                type: "addresses",
-                attributes: {
-                  latitude: 40.771913,
-                  longitude: -73.9673735,
-                  street_1: "5th Avenue",
-                  city: "New York",
-                  state_code: "NY"
-                }
-              },
-              {
-                type: "people",
-                attributes: {
-                  first_name: "John",
-                  last_name: "Doe",
-                  canvas_response: "leaning_for",
-                  party_affiliation: "Democrat"
-                }
-              }
-            ]
-          }, token
-
-          expect(last_response.status).to eq 200
-
-          expect(Person.count).to eq 1
-          expect(Address.count).to eq 1
-
-
-          new_address = Address.last
-          # basic fields
-          expect(new_address.latitude).to eq 40.771913
-          expect(new_address.longitude).to eq -73.9673735
-          expect(new_address.street_1)
-          expect(new_address.city).to eq "New York"
-          expect(new_address.street_1).to eq "5th Avenue"
-          expect(new_address.state_code).to eq "NY"
-          # USPS verified fields
-          expect(new_address.usps_verified_street_1).to eq "5 AVENUE A"
-          expect(new_address.usps_verified_street_2).to eq ""
-          expect(new_address.usps_verified_city).to eq "NEW YORK"
-          expect(new_address.usps_verified_state).to eq "NY"
-          expect(new_address.usps_verified_zip).to eq "10009-7944"
-
-          new_person = Person.last
-          expect(new_person.first_name).to eq "John"
-          expect(new_person.last_name).to eq "Doe"
-          expect(new_person.leaning_for?).to be true
-          expect(new_person.democrat_affiliation?).to be true
-
-          expect(new_person.address).to eq new_address
-          expect(new_address.most_supportive_resident).to eq new_person
-          expect(new_address.best_canvas_response).to eq new_person.canvas_response
-        end
-      end
-
-      context "when it fails creating the visit" do
-        it "should return an error response" do
-          address = create(:address, id: 1)
-
-          authenticated_post "visits", {
-            data: {
-              attributes: { duration_sec: 200 },
-              relationships: { address: { data: { id: 1, type: "addresses" } }, person: { data: { id: 10, type: "people" } } }
-            },
-            included: [ { type: "addresses", id: 1, attributes: { } }, { type: "people", id: 10, attributes: {} } ]
-          }, token
-          expect(last_response.status).to eq 404
-          expect(json.errors.length).to eq 1
-          error = json.errors.first
-          expect(error.id).to eq "RECORD_NOT_FOUND"
-          expect(error.title).to eq "Record not found"
-          expect(error.detail).to eq "Couldn't find Person with 'id'=10"
-          expect(error.status).to eq 404
         end
       end
     end

--- a/spec/requests/api/visit_spec.rb
+++ b/spec/requests/api/visit_spec.rb
@@ -161,7 +161,7 @@ describe "Visit API" do
                       canvas_response: "leaning_for",
                       party_affiliation: "Democrat",
                       email: "john@doe.com",
-                      phone: "12345",
+                      phone: "555-555-1212",
                       preferred_contact_method: "phone"
                     }
                   }
@@ -188,7 +188,7 @@ describe "Visit API" do
               expect(modified_person.leaning_for?).to be true
               expect(modified_person.democrat_affiliation?).to be true
               expect(modified_person.email).to eq "john@doe.com"
-              expect(modified_person.phone).to eq "12345"
+              expect(modified_person.phone).to eq "555-555-1212"
               expect(modified_person.contact_by_phone?).to be true
 
               expect(modified_person.address).to eq modified_address
@@ -233,7 +233,7 @@ describe "Visit API" do
                       canvas_response: "leaning_for",
                       party_affiliation: "Democrat",
                       email: "john@doe.com",
-                      phone: "12345",
+                      phone: "555-555-1212",
                       preferred_contact_method: "phone"
                     }
                   }
@@ -261,7 +261,7 @@ describe "Visit API" do
               expect(new_person.leaning_for?).to be true
               expect(new_person.democrat_affiliation?).to be true
               expect(new_person.email).to eq "john@doe.com"
-              expect(new_person.phone).to eq "12345"
+              expect(new_person.phone).to eq "555-555-1212"
               expect(new_person.contact_by_phone?).to be true
 
               expect(new_person.address).to eq modified_address
@@ -307,7 +307,7 @@ describe "Visit API" do
                       canvas_response: "leaning_for",
                       party_affiliation: "Democrat",
                       email: "john@doe.com",
-                      phone:"12345",
+                      phone:"555-555-1212",
                       preferred_contact_method: "phone"
                     }
                   },
@@ -319,7 +319,7 @@ describe "Visit API" do
                       canvas_response: "strongly_for",
                       party_affiliation: "Republican",
                       email: "jane@doe.com",
-                      phone: "54321",
+                      phone: "555-555-1212",
                       preferred_contact_method: "email"
                     }
                   }
@@ -346,7 +346,7 @@ describe "Visit API" do
               expect(modified_person.leaning_for?).to be true
               expect(modified_person.democrat_affiliation?).to be true
               expect(modified_person.email).to eq "john@doe.com"
-              expect(modified_person.phone).to eq "12345"
+              expect(modified_person.phone).to eq "555-555-1212"
               expect(modified_person.contact_by_phone?).to be true
 
               new_person = Person.find_by(first_name: "Jane")
@@ -355,7 +355,7 @@ describe "Visit API" do
               expect(new_person.strongly_for?).to be true
               expect(new_person.republican_affiliation?).to be true
               expect(new_person.email).to eq "jane@doe.com"
-              expect(new_person.phone).to eq "54321"
+              expect(new_person.phone).to eq "555-555-1212"
               expect(new_person.contact_by_email?).to be true
 
               expect(modified_person.address).to eq modified_address
@@ -392,7 +392,7 @@ describe "Visit API" do
                     canvas_response: "leaning_for",
                     party_affiliation: "Democrat",
                     email: "john@doe.com",
-                    phone: "12345",
+                    phone: "555-555-1212",
                     preferred_contact_method: "phone"
                   }
                 }
@@ -426,7 +426,7 @@ describe "Visit API" do
             expect(new_person.leaning_for?).to be true
             expect(new_person.democrat_affiliation?).to be true
             expect(new_person.email).to eq "john@doe.com"
-            expect(new_person.phone).to eq "12345"
+            expect(new_person.phone).to eq "555-555-1212"
             expect(new_person.contact_by_phone?).to be true
 
             expect(new_person.address).to eq new_address

--- a/spec/serializers/person_serializer_spec.rb
+++ b/spec/serializers/person_serializer_spec.rb
@@ -57,15 +57,15 @@ describe PersonSerializer, :type => :serializer do
       end
 
       it 'has a phone' do
-        expect(subject['phone'].to eql(resource.phone))
+        expect(subject['phone']).to eql(resource.phone)
       end
 
       it 'has an email' do
-        expect(subject['email'].to eql(resource.email))
+        expect(subject['email']).to eql(resource.email)
       end
 
       it 'has a preferred_contact_method' do
-        expect(subject['preferred_contact_method'].to eql(resource.preferred_contact_method))
+        expect(subject['preferred_contact_method']).to eql(resource.preferred_contact_method)
       end
     end
 

--- a/spec/serializers/person_serializer_spec.rb
+++ b/spec/serializers/person_serializer_spec.rb
@@ -55,6 +55,18 @@ describe PersonSerializer, :type => :serializer do
       it 'has a updated_at' do
         expect(subject['updated_at']).to eql(resource.updated_at)
       end
+
+      it 'has a phone' do
+        expect(subject['phone'].to eql(resource.phone))
+      end
+
+      it 'has an email' do
+        expect(subject['email'].to eql(resource.email))
+      end
+
+      it 'has a preferred_contact_method' do
+        expect(subject['preferred_contact_method'].to eql(resource.preferred_contact_method))
+      end
     end
 
     context 'relationships' do


### PR DESCRIPTION
- [Asana task: Add email, phone number to API](https://app.asana.com/0/60127409159606/62782824271170)
- [Asana task: Add preferred contact method](https://app.asana.com/0/60127409159606/62782824271174)
# Description

Adds listed fields to the `people` table and the `Person` model. I'm hoping I made the correct guess here, since the task didn't explicitly state it's for users or people. People make more sense to me in the context.
# Notes
- The default value for `preferred_contact_method` is email.
- `email` and `phone` are nullable
- The enums for  `preferred_contact_method` are `contact_by_phone?/!` and `contact_by_email?/!` just to make the intent a bit clearer.
- Specs were added first, so they should provide sufficient coverage.
