### PR TITLE
Fix issue with friends leaderboards not getting populated on facebook user signup

### DIFF
--- a/app/workers/initialize_new_facebook_user_worker.rb
+++ b/app/workers/initialize_new_facebook_user_worker.rb
@@ -1,0 +1,9 @@
+class InitializeNewFacebookUserWorker
+  include Sidekiq::Worker
+
+  def perform(user_id)
+    AddFacebookFriendsWorker.new.perform(user_id)
+    UpdateUsersLeaderboardsWorker.new.perform(user_id)
+  end
+
+end

--- a/spec/requests/api/tokens_spec.rb
+++ b/spec/requests/api/tokens_spec.rb
@@ -93,7 +93,7 @@ describe "Tokens API" do
       end
 
       after do
-        AddFacebookFriendsWorker.drain
+        InitializeNewFacebookUserWorker.drain
       end
 
       context "when the user does not already exist" do
@@ -111,7 +111,7 @@ describe "Tokens API" do
           expect(json.expires_in).to eq 7200
           expect(json.token_type).to eq "bearer"
 
-          expect(AddFacebookFriendsWorker.jobs.size).to eq 1
+          expect(InitializeNewFacebookUserWorker.jobs.size).to eq 1
         end
 
         it "fills in missing information from facebook data" do


### PR DESCRIPTION
- [Asana task: Figure out bug with not having friends leaderboards populated](https://app.asana.com/0/60127409159606/62782824271112)
# Description

I'm hoping this should fix the issue, but I'm not completely positive this was the issue discussed in the asana task to begin with.

In any case, my diagnosis was that `AddFacebookFriendsWorker` and `UpdateUsersLeaderboardsWorker` run concurrently, so it can easily happen that one is done with its work before the other, when they should in fact execute in a certain order.

This PR makes it so instead a third worker is called, which calls the two in synchronous order.

The specs didn't really have to be updated, other than making sure the new, correct worker has jobs active.
# Notes

I'm not sure I like how all of this is structured now.

`AddFacebookFriendsWorker` could now easily be a scenario, since it's never called outside of `InitializeFacebookUserWorker` and us always performed synchronously from within that worker.
