### PR TITLE
Fix/add validators to phone and email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'leaderboard'
 
 gem 'parse-ruby-client'
 
+gem 'phonelib'
+
 # paperclip master currently doesn't work with new version of AWS SDK
 gem 'paperclip', :git=> 'https://github.com/thoughtbot/paperclip', :ref => '523bd46c768226893f23889079a7aa9c73b57d68'
 

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'leaderboard'
 gem 'parse-ruby-client'
 
 gem 'phonelib'
+gem 'email_validator'
 
 # paperclip master currently doesn't work with new version of AWS SDK
 gem 'paperclip', :git=> 'https://github.com/thoughtbot/paperclip', :ref => '523bd46c768226893f23889079a7aa9c73b57d68'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,6 +307,7 @@ DEPENDENCIES
   doorkeeper
   dotenv-rails
   easypost
+  email_validator
   factory_girl_rails
   faker
   fakeredis

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,8 +77,7 @@ GEM
     bullet (4.14.10)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.9.0)
-    celluloid (0.17.1.2)
-      bundler
+    celluloid (0.17.2)
       celluloid-essentials
       celluloid-extras
       celluloid-fsm
@@ -182,6 +181,7 @@ GEM
       faraday
       faraday_middleware
     pg (0.18.3)
+    phonelib (0.5.4)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -318,6 +318,7 @@ DEPENDENCIES
   paperclip!
   parse-ruby-client
   pg
+  phonelib
   pry
   pry-nav
   pry-rails

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,6 +1,7 @@
 class Person < ActiveRecord::Base
   belongs_to :address
   validates :phone, phone: { possible: true, allow_blank: true }
+  validates :email, email: true, allow_blank: true
 
   enum canvas_response: {
     unknown: "Unknown",

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,5 +1,6 @@
 class Person < ActiveRecord::Base
   belongs_to :address
+  validates :phone, phone: { possible: true, allow_blank: true }
 
   enum canvas_response: {
     unknown: "Unknown",

--- a/config/initializers/phonelib.rb
+++ b/config/initializers/phonelib.rb
@@ -1,0 +1,1 @@
+Phonelib.default_country = 'US'

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -22,6 +22,39 @@ describe Person do
     it { should belong_to(:address) }
   end
 
+  context 'validations' do
+    describe 'phone validations' do
+      before(:each) do
+        @person = create(:person)
+      end
+
+      it 'should accept a 11 digit number that looks like a phone without hyphens' do
+        @person.phone = '5555551212'
+        expect(@person).to be_valid
+      end
+
+      it 'should accept a 11 digit number that looks like a phone with hyphens' do
+        @person.phone = '555-555-1212'
+        expect(@person).to be_valid
+      end
+
+      it 'should not accept a phone number without an area code' do
+        @person.phone = '5551212'
+        expect(@person).to_not be_valid
+      end
+
+      it 'should not accept a random digit string as a phone' do
+        @person.phone = '12345'
+        expect(@person).to_not be_valid
+      end
+
+      it 'should not accept alphas as a phone' do
+        @person.phone = 'abc-abc-abcd'
+        expect(@person).to_not be_valid
+      end
+    end
+  end
+
   it "has a working 'canvas_response' enum" do
     person = create(:person)
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -23,11 +23,10 @@ describe Person do
   end
 
   context 'validations' do
+    before(:each) do
+      @person = create(:person)
+    end
     describe 'phone validations' do
-      before(:each) do
-        @person = create(:person)
-      end
-
       it 'should accept a 11 digit number that looks like a phone without hyphens' do
         @person.phone = '5555551212'
         expect(@person).to be_valid
@@ -50,6 +49,24 @@ describe Person do
 
       it 'should not accept alphas as a phone' do
         @person.phone = 'abc-abc-abcd'
+        expect(@person).to_not be_valid
+      end
+    end
+
+    describe 'email validations' do
+      it 'should accept a valid email' do
+        @person.email = 'juan@example.com'
+        expect(@person).to be_valid
+      end
+
+      it 'should not accept a invalid email' do
+        @person.email = 'juan@example'
+        expect(@person).to_not be_valid
+        @person.email = 'juan'
+        expect(@person).to_not be_valid
+        @person.email = 'example.com'
+        expect(@person).to_not be_valid
+        @person.email = 'juan@example.com123'
         expect(@person).to_not be_valid
       end
     end

--- a/spec/requests/api/visit_spec.rb
+++ b/spec/requests/api/visit_spec.rb
@@ -161,7 +161,7 @@ describe "Visit API" do
                       canvas_response: "leaning_for",
                       party_affiliation: "Democrat",
                       email: "john@doe.com",
-                      phone: "12345",
+                      phone: "555-555-1212",
                       preferred_contact_method: "phone"
                     }
                   }
@@ -188,7 +188,7 @@ describe "Visit API" do
               expect(modified_person.leaning_for?).to be true
               expect(modified_person.democrat_affiliation?).to be true
               expect(modified_person.email).to eq "john@doe.com"
-              expect(modified_person.phone).to eq "12345"
+              expect(modified_person.phone).to eq "555-555-1212"
               expect(modified_person.contact_by_phone?).to be true
 
               expect(modified_person.address).to eq modified_address
@@ -233,7 +233,7 @@ describe "Visit API" do
                       canvas_response: "leaning_for",
                       party_affiliation: "Democrat",
                       email: "john@doe.com",
-                      phone: "12345",
+                      phone: "555-555-1212",
                       preferred_contact_method: "phone"
                     }
                   }
@@ -261,7 +261,7 @@ describe "Visit API" do
               expect(new_person.leaning_for?).to be true
               expect(new_person.democrat_affiliation?).to be true
               expect(new_person.email).to eq "john@doe.com"
-              expect(new_person.phone).to eq "12345"
+              expect(new_person.phone).to eq "555-555-1212"
               expect(new_person.contact_by_phone?).to be true
 
               expect(new_person.address).to eq modified_address
@@ -307,7 +307,7 @@ describe "Visit API" do
                       canvas_response: "leaning_for",
                       party_affiliation: "Democrat",
                       email: "john@doe.com",
-                      phone:"12345",
+                      phone:"555-555-1212",
                       preferred_contact_method: "phone"
                     }
                   },
@@ -319,7 +319,7 @@ describe "Visit API" do
                       canvas_response: "strongly_for",
                       party_affiliation: "Republican",
                       email: "jane@doe.com",
-                      phone: "54321",
+                      phone: "555-555-1212",
                       preferred_contact_method: "email"
                     }
                   }
@@ -346,7 +346,7 @@ describe "Visit API" do
               expect(modified_person.leaning_for?).to be true
               expect(modified_person.democrat_affiliation?).to be true
               expect(modified_person.email).to eq "john@doe.com"
-              expect(modified_person.phone).to eq "12345"
+              expect(modified_person.phone).to eq "555-555-1212"
               expect(modified_person.contact_by_phone?).to be true
 
               new_person = Person.find_by(first_name: "Jane")
@@ -355,7 +355,7 @@ describe "Visit API" do
               expect(new_person.strongly_for?).to be true
               expect(new_person.republican_affiliation?).to be true
               expect(new_person.email).to eq "jane@doe.com"
-              expect(new_person.phone).to eq "54321"
+              expect(new_person.phone).to eq "555-555-1212"
               expect(new_person.contact_by_email?).to be true
 
               expect(modified_person.address).to eq modified_address
@@ -392,7 +392,7 @@ describe "Visit API" do
                     canvas_response: "leaning_for",
                     party_affiliation: "Democrat",
                     email: "john@doe.com",
-                    phone: "12345",
+                    phone: "555-555-1212",
                     preferred_contact_method: "phone"
                   }
                 }
@@ -426,7 +426,7 @@ describe "Visit API" do
             expect(new_person.leaning_for?).to be true
             expect(new_person.democrat_affiliation?).to be true
             expect(new_person.email).to eq "john@doe.com"
-            expect(new_person.phone).to eq "12345"
+            expect(new_person.phone).to eq "555-555-1212"
             expect(new_person.contact_by_phone?).to be true
 
             expect(new_person.address).to eq new_address


### PR DESCRIPTION
Adds validators for phone and email. Should protect against obviously wrong data coming through from ios app.
