### PR TITLE
Added context for included score for visit serializer

### DIFF
--- a/spec/serializers/ranking_serializer_spec.rb
+++ b/spec/serializers/ranking_serializer_spec.rb
@@ -53,7 +53,7 @@ describe RankingSerializer, :type => :serializer do
     end
 
     context "included" do
-      context "when including" do
+      context "when including user" do
         let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer, include: ["user"]) }
 
         subject do

--- a/spec/serializers/visit_serializer_spec.rb
+++ b/spec/serializers/visit_serializer_spec.rb
@@ -88,6 +88,20 @@ describe VisitSerializer, :type => :serializer do
     end
 
     context "included" do
+      context "when including score" do
+        let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer, include: ["score"]) }
+
+        subject do
+          JSON.parse(serialization.to_json)["included"]
+        end
+
+        it "should not be empty" do
+          expect(subject).not_to be_nil
+          expect(subject.first["id"]).not_to be nil
+          expect(subject.first["type"]).to eq "scores"
+        end
+      end
+
       subject do
         JSON.parse(serialization.to_json)["included"]
       end


### PR DESCRIPTION
- [Asana task: Write specs for visit serializer for including score](https://app.asana.com/0/60127409159606/65101193837093)
# Description

Pretty straightforward. We have a similar spec for including user in the rankings serializer, so I wrote one for visit, when including score, since this is something we do in the `POST /visits` endpoint.
