### PR TITLE
Removed relationship object from specs

### DIFF
--- a/spec/requests/api/visit_spec.rb
+++ b/spec/requests/api/visit_spec.rb
@@ -21,7 +21,6 @@ describe "Visit API" do
           authenticated_post "visits", {
             data: {
               attributes: { duration_sec: 200 },
-              relationships: { address: { data: { id: 1, type: "addresses" } } }
             },
             included: [ { id: 1, type: "addresses" } ]
           }, token
@@ -50,7 +49,6 @@ describe "Visit API" do
             authenticated_post "visits", {
               data: {
                 attributes: { duration_sec: 200 },
-                relationships: { address: { data: { id: 1, type: "addresses" } } }
               },
               included: [ { id: 1, type: "addresses" } ]
             }, token
@@ -68,7 +66,6 @@ describe "Visit API" do
             authenticated_post "visits", {
               data: {
                 attributes: { duration_sec: 200 },
-                relationships: { address: { data: { id: 1, type: "addresses" } } }
               },
               included: [ { id: 1, type: "addresses" } ]
             }, token
@@ -89,7 +86,6 @@ describe "Visit API" do
             authenticated_post "visits", {
               data: {
                 attributes: { duration_sec: 200 },
-                relationships: { address: { data: { id: 1, type: "addresses" } } }
               },
               included: [ { id: 1, type: "addresses" } ]
             }, token
@@ -110,7 +106,6 @@ describe "Visit API" do
             authenticated_post "visits", {
               data: {
                 attributes: { duration_sec: 200 },
-                relationships: { address: { data: { id: 1, type: "addresses" } } }
               },
               included: [ { id: 1, type: "addresses" } ]
             }, token
@@ -138,10 +133,6 @@ describe "Visit API" do
               authenticated_post "visits", {
                 data: {
                   attributes: { duration_sec: 200 },
-                  relationships: {
-                    address: { data: { id: 1, type: "addresses" } },
-                    person: { data: { id: 10, type: "people" } }
-                  }
                 },
                 included: [
                   {
@@ -213,10 +204,6 @@ describe "Visit API" do
               authenticated_post "visits", {
                 data: {
                   attributes: { duration_sec: 200 },
-                  relationships: {
-                    address: { data: { id: 1, type: "addresses" } },
-                    person: { data: { id: 10, type: "people" } }
-                  }
                 },
                 included: [
                   {
@@ -287,11 +274,7 @@ describe "Visit API" do
 
               authenticated_post "visits", {
                 data: {
-                  attributes: { duration_sec: 200 },
-                  relationships: {
-                    address: { data: { id: 1, type: "addresses" } },
-                    person: { data: { id: 10, type: "people" } }
-                  }
+                  attributes: { duration_sec: 200 }
                 },
                 included: [
                   {
@@ -458,7 +441,6 @@ describe "Visit API" do
           authenticated_post "visits", {
             data: {
               attributes: { duration_sec: 200 },
-              relationships: { address: { data: { id: 1, type: "addresses" } }, person: { data: { id: 10, type: "people" } } }
             },
             included: [ { type: "addresses", id: 1, attributes: { } }, { type: "people", id: 10, attributes: {} } ]
           }, token
@@ -481,7 +463,6 @@ describe "Visit API" do
           authenticated_post "visits", {
             data: {
               attributes: { duration_sec: 200 },
-              relationships: { address: { data: { id: 1, type: "addresses" } } }
             },
             included: [ { id: 1, type: "addresses", attributes: { best_canvas_response: best_canvas_response } } ]
           }, token


### PR DESCRIPTION
- [Asana task: Remove relationship object from 'POST /visits' request](https://app.asana.com/0/60127409159606/65101193837103)
# Description

From #59

> We do not enforce having the relationship object in the request. It's not needed for our functionality and we basically ignore it, but it is defined in the JSON API spec. Then again, the spec doesn't explicitly define how to include related records in PUSH/POST/PATCH requests at all. Since that's the case, and since we don't need the relationship object for anything in this scenario, it might be best to just outright remove it from the specs and the API documentation.

All this really needed was removing the relationship object from the specs. It was never really used anywhere in the actual code
