### PR TITLE
Fix serializer to remove exposing phone/email/etc with Person

### DIFF
--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -12,6 +12,7 @@ class TokensController < Doorkeeper::TokensController
     handle_token_exception e
     Raven.capture_exception e
   rescue Koala::Facebook::AuthenticationError, ActiveRecord::RecordNotFound => e
+    Raven.capture_exception e
     error_hash = ErrorSerializer.serialize(e)
     render json: error_hash, status: error_hash[:errors][0][:status]
   end

--- a/app/serializers/person_serializer.rb
+++ b/app/serializers/person_serializer.rb
@@ -1,6 +1,6 @@
 class PersonSerializer < ActiveModel::Serializer
   attributes :id, :first_name, :last_name,
-    :party_affiliation, :canvas_response, :created_at, :updated_at
+    :party_affiliation, :canvas_response, :created_at, :updated_at, :previously_participated_in_caucus_or_primary, :preferred_contact_method
 
   belongs_to :address
 end

--- a/app/serializers/person_serializer.rb
+++ b/app/serializers/person_serializer.rb
@@ -3,4 +3,9 @@ class PersonSerializer < ActiveModel::Serializer
     :party_affiliation, :canvas_response, :created_at, :updated_at, :previously_participated_in_caucus_or_primary, :preferred_contact_method
 
   belongs_to :address
+
+  def preferred_contact_method
+  	return "phone" if object.contact_by_phone?
+  	return "email" if object.contact_by_email?
+  end
 end

--- a/app/serializers/person_serializer.rb
+++ b/app/serializers/person_serializer.rb
@@ -1,8 +1,6 @@
 class PersonSerializer < ActiveModel::Serializer
   attributes :id, :first_name, :last_name,
-    :party_affiliation, :canvas_response,
-    :previously_participated_in_caucus_or_primary,
-    :phone, :email, :preferred_contact_method
+    :party_affiliation, :canvas_response, :created_at, :updated_at
 
   belongs_to :address
 end

--- a/spec/serializers/person_serializer_spec.rb
+++ b/spec/serializers/person_serializer_spec.rb
@@ -3,7 +3,18 @@ require 'rails_helper'
 describe PersonSerializer, :type => :serializer do
 
   context 'individual resource representation' do
-    let(:resource) { build(:person) }
+    let(:resource) {
+      create(:person,
+        first_name: "Josh",
+        last_name: "Smith",
+        party_affiliation: "Democrat",
+        canvas_response: "Strongly for",
+        previously_participated_in_caucus_or_primary: false,
+        phone: "415-706-4899",
+        email: "josh@coderly.com",
+        preferred_contact_method: "phone"
+      )
+    }
 
     let(:serializer) { PersonSerializer.new(resource) }
     let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer) }
@@ -33,43 +44,45 @@ describe PersonSerializer, :type => :serializer do
       end
 
       it 'has a first_name' do
-        expect(subject['first_name']).to eql(resource.first_name)
+        expect(subject['first_name']).to eql "Josh"
       end
 
       it 'has a last_name' do
-        expect(subject['last_name']).to eql(resource.last_name)
+        expect(subject['last_name']).to eql "Smith"
       end
 
       it 'has a canvas_response' do
-        expect(subject['canvas_response']).to eql(resource.canvas_response)
+        expect(subject['canvas_response']).to eql "strongly_for"
       end
 
       it 'has a party_affiliation' do
-        expect(subject['party_affiliation']).to eql(resource.party_affiliation)
+        expect(subject['party_affiliation']).to eql "democrat_affiliation"
       end
 
       it 'has a created_at' do
-        expect(subject['created_at']).to eql(resource.created_at)
+        expect(subject['created_at']).to_not be_nil
+        expect(ActiveSupport::TimeZone['UTC'].parse(subject['created_at'])).to be_within(0.1).of(resource.created_at)
       end
 
       it 'has a updated_at' do
-        expect(subject['updated_at']).to eql(resource.updated_at)
+        expect(subject['updated_at']).to_not be_nil
+        expect(ActiveSupport::TimeZone['UTC'].parse(subject['updated_at'])).to be_within(0.1).of(resource.updated_at)
       end
 
       it 'has a previously_participated_in_caucus_or_primary' do
-        expect(subject['previously_participated_in_caucus_or_primary']).to eql(resource.previously_participated_in_caucus_or_primary)
+        expect(subject['previously_participated_in_caucus_or_primary']).to be_nil
       end
 
-      it 'has a phone' do
-        expect(subject['phone']).to eql(resource.phone)
+      it 'should not expose phone' do
+        expect(subject['phone']).to be_nil
       end
 
-      it 'has an email' do
-        expect(subject['email']).to eql(resource.email)
+      it 'should not expose email' do
+        expect(subject['email']).to be_nil
       end
 
-      it 'has a preferred_contact_method' do
-        expect(subject['preferred_contact_method']).to eql(resource.preferred_contact_method)
+      it 'should not expose a preferred_contact_method' do
+        expect(subject['preferred_contact_method']).to be_nil
       end
     end
 

--- a/spec/serializers/person_serializer_spec.rb
+++ b/spec/serializers/person_serializer_spec.rb
@@ -70,11 +70,11 @@ describe PersonSerializer, :type => :serializer do
       end
 
       it 'has a previously_participated_in_caucus_or_primary' do
-        expect(subject['previously_participated_in_caucus_or_primary']).to_not be_nil
+        expect(subject['previously_participated_in_caucus_or_primary']).to eql false
       end
 
       it 'has a preferred_contact_method' do
-        expect(subject['preferred_contact_method']).to_not be_nil
+        expect(subject['preferred_contact_method']).to eql "contact_by_phone"
       end
 
       it 'should not expose phone' do

--- a/spec/serializers/person_serializer_spec.rb
+++ b/spec/serializers/person_serializer_spec.rb
@@ -74,7 +74,7 @@ describe PersonSerializer, :type => :serializer do
       end
 
       it 'has a preferred_contact_method' do
-        expect(subject['preferred_contact_method']).to eql "contact_by_phone"
+        expect(subject['preferred_contact_method']).to eql "phone"
       end
 
       it 'should not expose phone' do

--- a/spec/serializers/person_serializer_spec.rb
+++ b/spec/serializers/person_serializer_spec.rb
@@ -70,7 +70,11 @@ describe PersonSerializer, :type => :serializer do
       end
 
       it 'has a previously_participated_in_caucus_or_primary' do
-        expect(subject['previously_participated_in_caucus_or_primary']).to be_nil
+        expect(subject['previously_participated_in_caucus_or_primary']).to_not be_nil
+      end
+
+      it 'has a preferred_contact_method' do
+        expect(subject['preferred_contact_method']).to_not be_nil
       end
 
       it 'should not expose phone' do
@@ -79,10 +83,6 @@ describe PersonSerializer, :type => :serializer do
 
       it 'should not expose email' do
         expect(subject['email']).to be_nil
-      end
-
-      it 'should not expose a preferred_contact_method' do
-        expect(subject['preferred_contact_method']).to be_nil
       end
     end
 


### PR DESCRIPTION
This removes the exposure of `phone`, `email`, and other attributes we don't want made public from the API.

https://app.asana.com/0/52390949460913/65745402561530
