### PR TITLE
Remove nils from person params

### DIFF
--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -29,7 +29,10 @@ class VisitsController < ApplicationController
 
   def people
     people = included_records.select{ |record| record[:type] == "people" }.map{ |person_params|
-      person = person_params.fetch(:attributes, {})
+      params = ActionController::Parameters.new(person_params.fetch(:attributes, {}))
+      person = params.permit(:first_name, :last_name, :email, :phone,
+        :preferred_contact_method, :previously_participated_in_caucus_or_primary,
+        :party_affiliation, :canvas_response)
       person_id  = person_params.fetch(:id, nil)
       person = person.merge(id: person_id) if person_id
       person

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -27,10 +27,10 @@ class Address < ActiveRecord::Base
   validates :state_code, presence: true
 
   def assign_most_supportive_resident(person)
-    current_resident = self.most_supportive_resident
-    there_is_no_current_resident = current_resident.nil?
+    current_most_supportive_resident = self.most_supportive_resident
+    there_is_no_current_most_supportive_resident = current_most_supportive_resident.nil?
 
-    if there_is_no_current_resident or person.more_supportive_than? current_resident
+    if there_is_no_current_most_supportive_resident or person.more_supportive_than? current_most_supportive_resident
       self.most_supportive_resident = person
       self.best_canvas_response = person.canvas_response
     end

--- a/lib/ground_game/scenario/create_visit.rb
+++ b/lib/ground_game/scenario/create_visit.rb
@@ -82,6 +82,11 @@ module GroundGame
         end
 
         def create_or_update_person_for_address(person_params, address, visit)
+          # We remove the nils from params since our client may not have some
+          # values, e.g. phone or email; we want to allow API values to
+          # remain unchanged in this event
+          person_params = remove_nils_from_params(person_params)
+
           person = Person.new_or_existing_from_params(person_params)
           person.address = address
 
@@ -93,6 +98,10 @@ module GroundGame
 
           person.save!
           person
+        end
+
+        def remove_nils_from_params(params)
+          params.compact
         end
 
         def update_most_supportive_resident(address, people)


### PR DESCRIPTION
This removes `nil` values sent by a client for `Person` params because these values can often be `nil` unintentionally, e.g. the client does not have `phone` or `email` from the API, so it may send `nil`, even though we do not want to override this value.
