### PR TITLE
Changed Person.preferred_contact_method default to nil

### DIFF
--- a/db/migrate/20151117081214_change_person_preferred_contact_method_default_to_none.rb
+++ b/db/migrate/20151117081214_change_person_preferred_contact_method_default_to_none.rb
@@ -1,0 +1,5 @@
+class ChangePersonPreferredContactMethodDefaultToNone < ActiveRecord::Migration
+  def change
+    change_column :people, :preferred_contact_method, :string, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151116230108) do
+ActiveRecord::Schema.define(version: 20151117081214) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -102,7 +102,7 @@ ActiveRecord::Schema.define(version: 20151116230108) do
     t.datetime "updated_at"
     t.string   "email"
     t.string   "phone"
-    t.string   "preferred_contact_method",                     default: "email"
+    t.string   "preferred_contact_method"
     t.boolean  "previously_participated_in_caucus_or_primary", default: false
   end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -16,7 +16,7 @@ describe Person do
     it { should have_db_column(:previously_participated_in_caucus_or_primary).of_type(:boolean).with_options(default: false) }
     it { should have_db_column(:phone).of_type(:string) }
     it { should have_db_column(:email).of_type(:string) }
-    it { should have_db_column(:preferred_contact_method).of_type(:string).with_options(default: "email") }
+    it { should have_db_column(:preferred_contact_method).of_type(:string).with_options(default: nil) }
   end
 
   context 'associations' do
@@ -118,7 +118,9 @@ describe Person do
   it "has a working 'preferred_contact_method' enum" do
     person = create(:person)
 
-    expect(person.contact_by_email?).to be true
+    expect(person.contact_by_email?).to be false
+    expect(person.contact_by_phone?).to be false
+    expect(person.preferred_contact_method.nil?).to be true
 
     person.contact_by_phone!
     expect(person.contact_by_phone?).to be true

--- a/spec/models/person_update_spec.rb
+++ b/spec/models/person_update_spec.rb
@@ -67,7 +67,7 @@ describe PersonUpdate do
       expect(person_update.old_canvass_response).to eq "unknown"
       expect(person_update.old_party_affiliation).to eq "unknown_affiliation"
       expect(person_update.old_phone).to be_nil
-      expect(person_update.old_preferred_contact_method).to eq "contact_by_email"
+      expect(person_update.old_preferred_contact_method).to be_nil
       expect(person_update.old_previously_participated_in_caucus_or_primary).to eq false
 
       expect(person_update.new_first_name).to eq "John"


### PR DESCRIPTION
- [Asana task: Change default for preferred contact method to none](https://app.asana.com/0/60127409159606/66582453001764)
# Description

I'm using the nil value here, not a string set to `"none"`.

I originally also wanted to update associated enum, but I can't think of a name that would make sense, since the current options are `contact_by_email?` and `contact_by_phone?`. I think it makes more sense as is. Both of those will be false if `preferred_contact_method.nil?` is true.
