### PR TITLE
Added last_canvas_response to address

### DIFF
--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -21,7 +21,7 @@ class VisitsController < ApplicationController
 
   def address
     address_params = included_records.select{ |record| record[:type] == "addresses" }.first
-    address = address_params.fetch(:attributes, {}).permit(:best_canvass_response, :latitude, :longitude, :street_1, :street_2, :city, :state_code, :zip_code)
+    address = address_params.fetch(:attributes, {}).permit(:best_canvass_response, :last_canvass_response, :latitude, :longitude, :street_1, :street_2, :city, :state_code, :zip_code)
     address_id = address_params.fetch(:id, nil)
     address = address.merge(id: address_id) if address_id
     address

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -26,6 +26,18 @@ class Address < ActiveRecord::Base
     not_home: "Not home"
   }
 
+  validates :last_canvass_response, inclusion: { in: [
+    "asked_to_leave",
+    "unknown",
+    "strongly_for",
+    "leaning_for",
+    "undecided",
+    "leaning_against",
+    "strongly_against",
+    "not_yet_visited",
+    "not_home"
+  ]}
+
   validates :state_code, presence: true
 
   def assign_most_supportive_resident(person)

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -15,28 +15,48 @@ class Address < ActiveRecord::Base
 
 
   enum best_canvass_response: {
-    asked_to_leave: "Asked to leave",
-    unknown: "Unknown",
-    strongly_for: "Strongly for",
-    leaning_for: "Leaning for",
-    undecided: "Undecided",
-    leaning_against: "Leaning against",
-    strongly_against: "Strongly against",
-    not_yet_visited: "Not yet visited",
-    not_home: "Not home"
+    best_is_asked_to_leave: "asked_to_leave",
+    best_is_unknown: "unknown",
+    best_is_strongly_for: "strongly_for",
+    best_is_leaning_for: "leaning_for",
+    best_is_undecided: "undecided",
+    best_is_leaning_against: "leaning_against",
+    best_is_strongly_against: "strongly_against",
+    best_is_not_yet_visited: "not_yet_visited",
+    best_is_not_home: "not_home"
   }
 
-  validates :last_canvass_response, inclusion: { in: [
-    "asked_to_leave",
-    "unknown",
-    "strongly_for",
-    "leaning_for",
-    "undecided",
-    "leaning_against",
-    "strongly_against",
-    "not_yet_visited",
-    "not_home"
-  ]}
+  def best_canvass_response
+    self[:best_canvass_response]
+  end
+
+  def best_canvass_response_was
+    enum_value = self.changed_attributes[:best_canvass_response]
+    string_value = Address.best_canvass_responses[enum_value]
+    string_value
+  end
+
+  enum last_canvass_response: {
+    last_is_asked_to_leave: "asked_to_leave",
+    last_is_unknown: "unknown",
+    last_is_strongly_for: "strongly_for",
+    last_is_leaning_for: "leaning_for",
+    last_is_undecided: "undecided",
+    last_is_leaning_against: "leaning_against",
+    last_is_strongly_against: "strongly_against",
+    last_is_not_yet_visited: "not_yet_visited",
+    last_is_not_home: "not_home"
+  }
+
+  def last_canvass_response
+    self[:last_canvass_response]
+  end
+
+  def last_canvass_response_was
+    enum_value = self.changed_attributes[:last_canvass_response]
+    string_value = Address.last_canvass_responses[enum_value]
+    string_value
+  end
 
   validates :state_code, presence: true
 
@@ -93,16 +113,16 @@ class Address < ActiveRecord::Base
     def self.ensure_best_canvas_response_valid!(params)
       canvass_response = params[:best_canvass_response]
 
-      if not best_canvass_response_value_valid?(canvass_response)
+      if not best_canvass_response_valid?(canvass_response)
         raise GroundGame::InvalidBestCanvassResponse.new(canvass_response)
       end
     end
 
-    def self.best_canvass_response_value_valid?(value)
-      value.nil? or allowed_best_canvass_response_values_for_setting_directly.include? value.to_sym
+    def self.best_canvass_response_valid?(value)
+      value.nil? or allowed_best_canvass_responses_for_setting_directly.include? value.to_sym
     end
 
-    def self.allowed_best_canvass_response_values_for_setting_directly
+    def self.allowed_best_canvass_responses_for_setting_directly
       [:asked_to_leave, :not_yet_visited, :not_home]
     end
 end

--- a/app/models/address_update.rb
+++ b/app/models/address_update.rb
@@ -31,6 +31,8 @@ class AddressUpdate < ActiveRecord::Base
       old_most_supportive_resident_id: address.most_supportive_resident_id_was,
       new_most_supportive_resident_id: address.most_supportive_resident_id,
       old_best_canvass_response: address.best_canvass_response_was,
-      new_best_canvass_response: address.best_canvass_response)
+      new_best_canvass_response: address.best_canvass_response,
+      old_last_canvass_response: address.last_canvass_response_was,
+      new_last_canvass_response: address.last_canvass_response)
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -4,13 +4,13 @@ class Person < ActiveRecord::Base
   validates :email, email: true, allow_blank: true
 
   enum canvass_response: {
-    unknown: "Unknown",
-    strongly_for: "Strongly for",
-    leaning_for: "Leaning for",
-    undecided: "Undecided",
-    leaning_against: "Leaning against",
-    strongly_against: "Strongly against",
-    asked_to_leave: "Asked to leave"
+    unknown: "unknown",
+    strongly_for: "strongly_for",
+    leaning_for: "leaning_for",
+    undecided: "undecided",
+    leaning_against: "leaning_against",
+    strongly_against: "strongly_against",
+    asked_to_leave: "asked_to_leave"
   }
 
   enum party_affiliation: {

--- a/app/serializers/address_serializer.rb
+++ b/app/serializers/address_serializer.rb
@@ -1,6 +1,6 @@
 class AddressSerializer < ActiveModel::Serializer
   attributes :latitude, :longitude, :street_1, :street_2, :city, :state_code,
-    :zip_code, :visited_at, :best_canvass_response
+    :zip_code, :visited_at, :best_canvass_response, :last_canvass_response
 
   belongs_to :most_supportive_resident
   has_many :people

--- a/db/migrate/20151117091849_add_last_canvas_response_to_addresses.rb
+++ b/db/migrate/20151117091849_add_last_canvas_response_to_addresses.rb
@@ -1,0 +1,5 @@
+class AddLastCanvasResponseToAddresses < ActiveRecord::Migration
+  def change
+    add_column :addresses, :last_canvass_response, :string, default: 'Unknown'
+  end
+end

--- a/db/migrate/20151117091849_add_last_canvas_response_to_addresses.rb
+++ b/db/migrate/20151117091849_add_last_canvas_response_to_addresses.rb
@@ -1,5 +1,5 @@
 class AddLastCanvasResponseToAddresses < ActiveRecord::Migration
   def change
-    add_column :addresses, :last_canvass_response, :string, default: 'Unknown'
+    add_column :addresses, :last_canvass_response, :string, default: "unknown"
   end
 end

--- a/db/migrate/20151118100746_change_default_for_canvass_response.rb
+++ b/db/migrate/20151118100746_change_default_for_canvass_response.rb
@@ -1,0 +1,6 @@
+class ChangeDefaultForCanvassResponse < ActiveRecord::Migration
+  def change
+    change_column :addresses, :best_canvass_response, :string, default: 'not_yet_visited'
+    change_column :people, :canvass_response, :string, default: 'unknown'
+  end
+end

--- a/db/migrate/20151118144034_add_last_canvass_response_tracking_to_address_updates.rb
+++ b/db/migrate/20151118144034_add_last_canvass_response_tracking_to_address_updates.rb
@@ -1,0 +1,6 @@
+class AddLastCanvassResponseTrackingToAddressUpdates < ActiveRecord::Migration
+  def change
+    add_column :address_updates, :old_last_canvass_response, :string
+    add_column :address_updates, :new_last_canvass_response, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -38,7 +38,7 @@ ActiveRecord::Schema.define(version: 20151117091849) do
     t.string   "usps_verified_state"
     t.string   "usps_verified_zip"
     t.string   "best_canvass_response",       default: "Not yet visited"
-    t.string   "last_canvass_response",       default: "Unknown"
+    t.string   "last_canvass_response",       default: "unknown"
   end
 
   create_table "devices", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151118100746) do
+ActiveRecord::Schema.define(version: 20151118144034) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,8 @@ ActiveRecord::Schema.define(version: 20151118100746) do
     t.datetime "new_visited_at"
     t.integer  "new_most_supportive_resident_id"
     t.string   "new_best_canvass_response"
+    t.string   "old_last_canvass_response"
+    t.string   "new_last_canvass_response"
   end
 
   create_table "addresses", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151116230108) do
+ActiveRecord::Schema.define(version: 20151117091849) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 20151116230108) do
     t.string   "usps_verified_state"
     t.string   "usps_verified_zip"
     t.string   "best_canvass_response",       default: "Not yet visited"
+    t.string   "last_canvass_response",       default: "Unknown"
   end
 
   create_table "devices", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151117091849) do
+ActiveRecord::Schema.define(version: 20151118100746) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 20151117091849) do
     t.string   "usps_verified_city"
     t.string   "usps_verified_state"
     t.string   "usps_verified_zip"
-    t.string   "best_canvass_response",       default: "Not yet visited"
+    t.string   "best_canvass_response",       default: "not_yet_visited"
     t.string   "last_canvass_response",       default: "unknown"
   end
 
@@ -116,7 +116,7 @@ ActiveRecord::Schema.define(version: 20151117091849) do
   create_table "people", force: :cascade do |t|
     t.string   "first_name"
     t.string   "last_name"
-    t.string   "canvass_response",                             default: "Unknown"
+    t.string   "canvass_response",                             default: "unknown"
     t.string   "party_affiliation",                            default: "Unknown"
     t.integer  "address_id"
     t.datetime "created_at"

--- a/lib/ground_game/scenario/create_visit.rb
+++ b/lib/ground_game/scenario/create_visit.rb
@@ -65,8 +65,6 @@ module GroundGame
           # instead of at the model level.
           address.best_canvass_response = :not_home if address.new_record? and address_params[:best_canvass_response].nil?
 
-          address.ensure_not_recently_visited!
-
           # I do not like that this is here, but I couldn't think of a better way.
           # AddressUpdate absolutely needs to be created after initializing/fetching
           # and updating, but before saving the address due to it needing access to

--- a/lib/ground_game/scenario/create_visit.rb
+++ b/lib/ground_game/scenario/create_visit.rb
@@ -63,7 +63,7 @@ module GroundGame
           # In the case of a visit, however, it makes more sense for the default to ne "not home"
           # Due to this, it makes more sense to set that default here, in the CreateVisit scenario
           # instead of at the model level.
-          address.best_canvass_response = :not_home if address.new_record? and address_params[:best_canvass_response].nil?
+          address.best_canvass_response = "not_home" if address.new_record? and address_params[:best_canvass_response].nil?
 
           # I do not like that this is here, but I couldn't think of a better way.
           # AddressUpdate absolutely needs to be created after initializing/fetching

--- a/lib/ground_game/scenario/create_visit.rb
+++ b/lib/ground_game/scenario/create_visit.rb
@@ -67,16 +67,14 @@ module GroundGame
             raise GroundGame::VisitNotAllowed if address.recently_visited?
           end
 
-
           address.assign_attributes(address_params)
 
           assign_address_best_canvas_response(address, address_params)
           assign_address_last_canvas_response(address, address_params)
 
-          # I do not like that this is here, but I couldn't think of a better way.
           # AddressUpdate absolutely needs to be created after initializing/fetching
           # and updating, but before saving the address due to it needing access to
-          # old and new address attributes.
+          # old and new address attribute values.
           AddressUpdate.create_for_visit_and_address(visit, address)
 
           address.save!

--- a/spec/lib/ground_game/scenario/create_visit_spec.rb
+++ b/spec/lib/ground_game/scenario/create_visit_spec.rb
@@ -565,6 +565,44 @@ module GroundGame
             expect(result.error.id).to eq "INVALID_BEST_CANVASS_RESPONSE"
           end
         end
+
+        describe "setting 'address.last_canvass_response'" do
+          before do
+            @address = create(:address, id: 1)
+            @visit_params = {}
+          end
+
+          it "sets it to 'best_canvass_response' if there are no 'people_params' or 'last_canvass_response' parameter" do
+            address_params = { id: 1, best_canvass_response: "not_home" }
+            people_params = []
+
+            CreateVisit.new(@visit_params, address_params, people_params, user).call
+
+            expect(@address.reload.last_canvass_response).to eq "not_home"
+          end
+
+          it "sets it to 'last_canvass_response' if there are no 'people_params'" do
+            address_params = { id: 1, best_canvass_response: "not_home", last_canvass_response: "asked_to_leave" }
+            people_params = []
+
+            CreateVisit.new(@visit_params, address_params, people_params, user).call
+
+            expect(@address.reload.last_canvass_response).to eq "asked_to_leave"
+          end
+
+          it "sets it to 'most_supportive_resident.canvas_response' if there are 'people_params'" do
+            address_params = { id: 1 }
+            people_params = [
+              { canvass_response: "leaning_for" },
+              { canvass_response: "strongly_for" },
+              { canvass_response: "leaning_against"}
+            ]
+
+            CreateVisit.new(@visit_params, address_params, people_params, user).call
+
+            expect(@address.reload.last_canvass_response).to eq "strongly_for"
+          end
+        end
       end
     end
   end

--- a/spec/lib/ground_game/scenario/create_visit_spec.rb
+++ b/spec/lib/ground_game/scenario/create_visit_spec.rb
@@ -47,7 +47,7 @@ module GroundGame
               id: 10,
               first_name: "John",
               last_name: "Doe",
-              canvass_response: "Leaning for",
+              canvass_response: "leaning_for",
               party_affiliation: "Democrat"
             }]
 
@@ -111,11 +111,11 @@ module GroundGame
 
                 people_params = [{
                   id: 10,
-                  canvass_response: "Leaning for",
+                  canvass_response: "leaning_for",
                   party_affiliation: "Democrat"
                 }, {
                   id: 11,
-                  canvass_response: "Strongly for",
+                  canvass_response: "strongly_for",
                   party_affiliation: "Independent"
                 }]
 
@@ -161,7 +161,7 @@ module GroundGame
                   id: 10,
                   first_name: "John",
                   last_name: "Doe",
-                  canvass_response: "Leaning for",
+                  canvass_response: "leaning_for",
                   party_affiliation: "Democrat"
                 }]
 
@@ -187,12 +187,12 @@ module GroundGame
                 people_params = [{
                   first_name: "John",
                   last_name: "Doe",
-                  canvass_response: "Leaning for",
+                  canvass_response: "leaning_for",
                   party_affiliation: "Democrat"
                 }, {
                   first_name: "Jane",
                   last_name: "Doe",
-                  canvass_response: "Strongly for",
+                  canvass_response: "strongly_for",
                   party_affiliation: "Independent"
                 }]
 
@@ -238,7 +238,7 @@ module GroundGame
                 people_params = [{
                   first_name: "John",
                   last_name: "Doe",
-                  canvass_response: "Leaning for",
+                  canvass_response: "leaning_for",
                   party_affiliation: "Democrat"
                 }]
 
@@ -282,7 +282,7 @@ module GroundGame
               expect(address_update.visit).to eq visit
               expect(address_update.address).to eq visit.address
               expect(address_update.created?).to be true
-              expect(address_update.address.not_home?).to be true
+              expect(address_update.address.best_is_not_home?).to be true
             end
 
             it "creates the visit, the address and the people", vcr: { cassette_name: "lib/ground_game/scenario/create_visit/successful_easypost_request" } do
@@ -290,7 +290,7 @@ module GroundGame
               people_params = [{
                 first_name: "John",
                 last_name: "Doe",
-                canvass_response: "Leaning for",
+                canvass_response: "leaning_for",
                 party_affiliation: "Democrat"
               }]
 
@@ -517,51 +517,51 @@ module GroundGame
 
           it "should be allowed for 'asked_to_leave'" do
             result = create_visit_with_address_best_canvass_response_set_to "asked_to_leave"
-            expect(@address.reload.asked_to_leave?).to be true
+            expect(@address.reload.best_is_asked_to_leave?).to be true
           end
 
           it "should be allowed for 'not_home'" do
             create_visit_with_address_best_canvass_response_set_to "not_home"
-            expect(@address.reload.not_home?).to be true
+            expect(@address.reload.best_is_not_home?).to be true
           end
 
           it "should be allowed for 'not_yet_visited" do
             create_visit_with_address_best_canvass_response_set_to "not_yet_visited"
-            expect(@address.reload.not_yet_visited?).to be true
+            expect(@address.reload.best_is_not_yet_visited?).to be true
           end
 
           it "should not be allowed for 'unknown'" do
             create_visit_with_address_best_canvass_response_set_to "unknown"
-            expect(@address.reload.unknown?).to be false
+            expect(@address.reload.best_is_unknown?).to be false
           end
 
           it "should not be allowed for 'strongly_for'" do
             result = create_visit_with_address_best_canvass_response_set_to "strongly_for"
-            expect(@address.reload.strongly_for?).to be false
+            expect(@address.reload.best_is_strongly_for?).to be false
             expect(result.error.id).to eq "INVALID_BEST_CANVASS_RESPONSE"
           end
 
           it "should not be allowed for 'leaning_for'" do
             result = create_visit_with_address_best_canvass_response_set_to "leaning_for"
-            expect(@address.reload.leaning_for?).to be false
+            expect(@address.reload.best_is_leaning_for?).to be false
             expect(result.error.id).to eq "INVALID_BEST_CANVASS_RESPONSE"
           end
 
           it "should not be allowed for 'undecided'" do
             result = create_visit_with_address_best_canvass_response_set_to "undecided"
-            expect(@address.reload.undecided?).to be false
+            expect(@address.reload.best_is_undecided?).to be false
             expect(result.error.id).to eq "INVALID_BEST_CANVASS_RESPONSE"
           end
 
           it "should not be allowed for 'leaning_against'" do
             result = create_visit_with_address_best_canvass_response_set_to "leaning_against"
-            expect(@address.reload.leaning_against?).to be false
+            expect(@address.reload.best_is_leaning_against?).to be false
             expect(result.error.id).to eq "INVALID_BEST_CANVASS_RESPONSE"
           end
 
           it "should not be allowed for 'strongly_against'" do
             result = create_visit_with_address_best_canvass_response_set_to "strongly_against"
-            expect(@address.reload.strongly_against?).to be false
+            expect(@address.reload.best_is_strongly_against?).to be false
             expect(result.error.id).to eq "INVALID_BEST_CANVASS_RESPONSE"
           end
         end
@@ -578,7 +578,7 @@ module GroundGame
 
             CreateVisit.new(@visit_params, address_params, people_params, user).call
 
-            expect(@address.reload.last_canvass_response).to eq "not_home"
+            expect(@address.reload.last_is_not_home?).to be true
           end
 
           it "sets it to 'last_canvass_response' if there are no 'people_params'" do
@@ -587,7 +587,7 @@ module GroundGame
 
             CreateVisit.new(@visit_params, address_params, people_params, user).call
 
-            expect(@address.reload.last_canvass_response).to eq "asked_to_leave"
+            expect(@address.reload.last_is_asked_to_leave?).to be true
           end
 
           it "sets it to 'most_supportive_resident.canvas_response' if there are 'people_params'" do
@@ -600,7 +600,7 @@ module GroundGame
 
             CreateVisit.new(@visit_params, address_params, people_params, user).call
 
-            expect(@address.reload.last_canvass_response).to eq "strongly_for"
+            expect(@address.reload.last_is_strongly_for?).to be true
           end
         end
       end

--- a/spec/lib/ground_game/scenario/match_address_spec.rb
+++ b/spec/lib/ground_game/scenario/match_address_spec.rb
@@ -48,7 +48,7 @@ module GroundGame
             expect(matched_address.city).to eq "New York"
             expect(matched_address.state_code).to eq "NY"
             expect(matched_address.zip_code).to eq ""
-            expect(matched_address.best_canvass_response).to eq "strongly_for"
+            expect(matched_address.best_is_strongly_for?).to be true
 
             expect(matched_address.most_supportive_resident_id).to eq 5
             expect(matched_address.people.map(&:id)).to contain_exactly 5, 6

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -18,7 +18,8 @@ describe Address do
     it {should have_db_column(:usps_verified_street_1).of_type(:string) }
     it {should have_db_column(:usps_verified_city).of_type(:string) }
     it {should have_db_column(:usps_verified_zip).of_type(:string) }
-    it {should have_db_column(:best_canvass_response).of_type(:string) }
+    it {should have_db_column(:best_canvass_response).of_type(:string).with_options(default: "Not yet visited") }
+    it {should have_db_column(:last_canvass_response).of_type(:string).with_options(default: "Unknown") }
   end
 
   context 'associations' do

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -18,7 +18,7 @@ describe Address do
     it {should have_db_column(:usps_verified_street_1).of_type(:string) }
     it {should have_db_column(:usps_verified_city).of_type(:string) }
     it {should have_db_column(:usps_verified_zip).of_type(:string) }
-    it {should have_db_column(:best_canvass_response).of_type(:string).with_options(default: "Not yet visited") }
+    it {should have_db_column(:best_canvass_response).of_type(:string).with_options(default: "not_yet_visited") }
     it {should have_db_column(:last_canvass_response).of_type(:string).with_options(default: "unknown") }
   end
 
@@ -29,9 +29,6 @@ describe Address do
 
   context 'validations' do
     it { should validate_presence_of(:state_code) }
-    it { should validate_inclusion_of(:last_canvass_response).in_array([
-      "asked_to_leave", "unknown", "strongly_for", "leaning_for", "undecided",
-      "leaning_against", "strongly_against", "not_yet_visited", "not_home"]) }
   end
 
   context 'scopes' do
@@ -50,31 +47,61 @@ describe Address do
   it "has a working 'best_canvass_response' enum" do
     address = create(:address)
 
-    expect(address.not_yet_visited?).to be true
+    expect(address.best_is_not_yet_visited?).to be true
 
-    address.not_home!
-    expect(address.not_home?).to be true
+    address.best_is_not_home!
+    expect(address.best_is_not_home?).to be true
 
-    address.unknown!
-    expect(address.unknown?).to be true
+    address.best_is_unknown!
+    expect(address.best_is_unknown?).to be true
 
-    address.strongly_for!
-    expect(address.strongly_for?).to be true
+    address.best_is_strongly_for!
+    expect(address.best_is_strongly_for?).to be true
 
-    address.leaning_for!
-    expect(address.leaning_for?).to be true
+    address.best_is_leaning_for!
+    expect(address.best_is_leaning_for?).to be true
 
-    address.undecided!
-    expect(address.undecided?).to be true
+    address.best_is_undecided!
+    expect(address.best_is_undecided?).to be true
 
-    address.leaning_against!
-    expect(address.leaning_against?).to be true
+    address.best_is_leaning_against!
+    expect(address.best_is_leaning_against?).to be true
 
-    address.strongly_against!
-    expect(address.strongly_against?).to be true
+    address.best_is_strongly_against!
+    expect(address.best_is_strongly_against?).to be true
 
-    address.asked_to_leave!
-    expect(address.asked_to_leave?).to be true
+    address.best_is_asked_to_leave!
+    expect(address.best_is_asked_to_leave?).to be true
+  end
+
+  it "has a working 'last_canvass_response' enum" do
+    address = create(:address)
+
+    expect(address.last_is_unknown?).to be true
+
+    address.last_is_not_yet_visited!
+    expect(address.last_is_not_yet_visited?).to be true
+
+    address.last_is_not_home!
+    expect(address.last_is_not_home?).to be true
+
+    address.last_is_strongly_for!
+    expect(address.last_is_strongly_for?).to be true
+
+    address.last_is_leaning_for!
+    expect(address.last_is_leaning_for?).to be true
+
+    address.last_is_undecided!
+    expect(address.last_is_undecided?).to be true
+
+    address.last_is_leaning_against!
+    expect(address.last_is_leaning_against?).to be true
+
+    address.last_is_strongly_against!
+    expect(address.last_is_strongly_against?).to be true
+
+    address.last_is_asked_to_leave!
+    expect(address.last_is_asked_to_leave?).to be true
   end
 
   describe "instance methods" do

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -188,5 +188,37 @@ describe Address do
         expect(address.reload.recently_visited?).to be false
       end
     end
+
+    describe "#best_canvass_response" do
+      it "returns the underlying string value" do
+        address = create(:address, best_canvass_response: "strongly_against")
+        address.best_is_leaning_for!
+        expect(address.best_canvass_response).to eq "leaning_for"
+      end
+    end
+
+    describe "#best_canvass_response_was" do
+      it "returns the underlying string value" do
+        address = create(:address, best_canvass_response: "strongly_against")
+        address.best_canvass_response = "leaning_for"
+        expect(address.best_canvass_response_was).to eq "strongly_against"
+      end
+    end
+
+    describe "#last_canvass_response" do
+      it "returns the underlying string value" do
+        address = create(:address, last_canvass_response: "strongly_against")
+        address.last_is_leaning_for!
+        expect(address.last_canvass_response).to eq "leaning_for"
+      end
+    end
+
+    describe "#last_canvass_response_was" do
+      it "returns the underlying string value" do
+        address = create(:address, last_canvass_response: "strongly_against")
+        address.last_canvass_response = "leaning_for"
+        expect(address.last_canvass_response_was).to eq "strongly_against"
+      end
+    end
   end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -189,40 +189,4 @@ describe Address do
       end
     end
   end
-
-  describe "class methods" do
-    describe ".new_or_existing_from_params" do
-      it "initializes a new address if the params do not contain an id", vcr: { cassette_name: "models/address/creates_a_new_address_if_the_params_do_not_contain_an_id" } do
-        expect(Address.count).to eq 0
-        params = { latitude: 1, longitude: 1 }
-        address = Address.new_or_existing_from_params(params)
-        expect(address.persisted?).to be false
-      end
-
-      it "fetches and updates (without save) an existing address if the params do contain an id" do
-        create(:address, id: 1, latitude: 0, longitude: 0)
-        params = { id: 1, latitude: 1, longitude: 1 }
-        address = Address.new_or_existing_from_params(params)
-        expect(Address.count).to eq 1
-        expect(address.changed?).to be true
-        expect(address.latitude).to eq 1
-        expect(address.longitude).to eq 1
-      end
-
-      it "throws an error if updating the same address twice in a short period" do
-        address = create(:address, id: 1, recently_visited?: true)
-        params = { id: 1, latitude: 1, longitude: 1 }
-        expect { Address.new_or_existing_from_params(params) }.to raise_error GroundGame::VisitNotAllowed
-      end
-    end
-
-    it "should raise an error if there's an invalid 'best_canvass_response' parameter value" do
-      create(:address, id: 1, latitude: 0, longitude: 0)
-      params = {
-        id: 1,
-        best_canvass_response: "strongly_for"
-      }
-      expect { Address.new_or_existing_from_params(params) }.to raise_error ArgumentError
-    end
-  end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -19,7 +19,7 @@ describe Address do
     it {should have_db_column(:usps_verified_city).of_type(:string) }
     it {should have_db_column(:usps_verified_zip).of_type(:string) }
     it {should have_db_column(:best_canvass_response).of_type(:string).with_options(default: "Not yet visited") }
-    it {should have_db_column(:last_canvass_response).of_type(:string).with_options(default: "Unknown") }
+    it {should have_db_column(:last_canvass_response).of_type(:string).with_options(default: "unknown") }
   end
 
   context 'associations' do
@@ -29,6 +29,9 @@ describe Address do
 
   context 'validations' do
     it { should validate_presence_of(:state_code) }
+    it { should validate_inclusion_of(:last_canvass_response).in_array([
+      "asked_to_leave", "unknown", "strongly_for", "leaning_for", "undecided",
+      "leaning_against", "strongly_against", "not_yet_visited", "not_home"]) }
   end
 
   context 'scopes' do

--- a/spec/models/address_update_spec.rb
+++ b/spec/models/address_update_spec.rb
@@ -20,6 +20,7 @@ describe AddressUpdate do
     it {should have_db_column(:old_visited_at).of_type(:datetime) }
     it {should have_db_column(:old_most_supportive_resident_id).of_type(:integer) }
     it {should have_db_column(:old_best_canvass_response).of_type(:string) }
+    it {should have_db_column(:old_last_canvass_response).of_type(:string) }
 
     it {should have_db_column(:new_latitude).of_type(:float) }
     it {should have_db_column(:new_longitude).of_type(:float) }
@@ -31,6 +32,7 @@ describe AddressUpdate do
     it {should have_db_column(:new_visited_at).of_type(:datetime) }
     it {should have_db_column(:new_most_supportive_resident_id).of_type(:integer) }
     it {should have_db_column(:new_best_canvass_response).of_type(:string) }
+    it {should have_db_column(:new_last_canvass_response).of_type(:string) }
   end
 
   context 'associations' do
@@ -85,7 +87,8 @@ describe AddressUpdate do
         zip_code: 'Old zip code',
         visited_at: DateTime.new(2014, 1, 2, 3, 4, 5),
         most_supportive_resident_id: 1,
-        best_canvass_response: "leaning_against")
+        best_canvass_response: "leaning_against",
+        last_canvass_response: "strongly_for")
 
       address.assign_attributes(
         latitude: 4,
@@ -97,7 +100,8 @@ describe AddressUpdate do
         zip_code: 'New zip code',
         visited_at: DateTime.new(2015, 1, 2, 3, 4, 5),
         most_supportive_resident_id: 2,
-        best_canvass_response: "strongly_for")
+        best_canvass_response: "strongly_for",
+        last_canvass_response: "leaning_against")
 
       address_update = AddressUpdate.create_for_visit_and_address(visit, address)
 
@@ -111,6 +115,7 @@ describe AddressUpdate do
       expect(address_update.old_visited_at).to eq DateTime.new(2014, 1, 2, 3, 4, 5)
       expect(address_update.old_most_supportive_resident_id).to eq 1
       expect(address_update.old_best_canvass_response).to eq "leaning_against"
+      expect(address_update.old_last_canvass_response).to eq "strongly_for"
 
       expect(address_update.new_latitude).to eq 4
       expect(address_update.new_longitude).to eq 5
@@ -122,6 +127,7 @@ describe AddressUpdate do
       expect(address_update.new_visited_at).to eq DateTime.new(2015, 1, 2, 3, 4, 5)
       expect(address_update.new_most_supportive_resident_id).to eq 2
       expect(address_update.new_best_canvass_response).to eq "strongly_for"
+      expect(address_update.new_last_canvass_response).to eq "leaning_against"
     end
   end
 end

--- a/spec/models/address_update_spec.rb
+++ b/spec/models/address_update_spec.rb
@@ -85,7 +85,7 @@ describe AddressUpdate do
         zip_code: 'Old zip code',
         visited_at: DateTime.new(2014, 1, 2, 3, 4, 5),
         most_supportive_resident_id: 1,
-        best_canvass_response: :leaning_against)
+        best_canvass_response: "leaning_against")
 
       address.assign_attributes(
         latitude: 4,
@@ -97,7 +97,7 @@ describe AddressUpdate do
         zip_code: 'New zip code',
         visited_at: DateTime.new(2015, 1, 2, 3, 4, 5),
         most_supportive_resident_id: 2,
-        best_canvass_response: :strongly_for)
+        best_canvass_response: "strongly_for")
 
       address_update = AddressUpdate.create_for_visit_and_address(visit, address)
 

--- a/spec/requests/api/address_spec.rb
+++ b/spec/requests/api/address_spec.rb
@@ -92,7 +92,7 @@ describe "Address API" do
           expect(address_attributes.state_code).to eq "NY"
           expect(address_attributes.zip_code).to eq ""
           expect(address_attributes.best_canvass_response).to eq "strongly_for"
-          expect(address_attributes.last_canvass_response).to_not eq nil
+          expect(address_attributes.last_canvass_response).not_to be_nil
           address_relationships = address_json.relationships
           expect(address_relationships.most_supportive_resident.data.id).to eq "5"
           expect(address_relationships.people.data.map(&:id)).to contain_exactly "5","6"

--- a/spec/requests/api/address_spec.rb
+++ b/spec/requests/api/address_spec.rb
@@ -92,11 +92,10 @@ describe "Address API" do
           expect(address_attributes.state_code).to eq "NY"
           expect(address_attributes.zip_code).to eq ""
           expect(address_attributes.best_canvass_response).to eq "strongly_for"
-
+          expect(address_attributes.last_canvass_response).to_not eq nil
           address_relationships = address_json.relationships
           expect(address_relationships.most_supportive_resident.data.id).to eq "5"
           expect(address_relationships.people.data.map(&:id)).to contain_exactly "5","6"
-
           expect(json.included.length).to eq 2
           expect(json.included.all? { |person| person.type == "people" }).to be true
           expect(json.included.all? { |person| person.relationships.address.data.id == "1" }).to be true

--- a/spec/requests/api/visit_spec.rb
+++ b/spec/requests/api/visit_spec.rb
@@ -536,47 +536,47 @@ describe "Visit API" do
 
         it "should be allowed for 'asked_to_leave'" do
           post_visit_with_address_best_canvass_response_set_to "asked_to_leave"
-          expect(@address.reload.asked_to_leave?).to be true
+          expect(@address.reload.best_is_asked_to_leave?).to be true
         end
 
         it "should be allowed for 'not_home'" do
           post_visit_with_address_best_canvass_response_set_to "not_home"
-          expect(@address.reload.not_home?).to be true
+          expect(@address.reload.best_is_not_home?).to be true
         end
 
         it "should be allowed for 'not_yet_visited" do
           post_visit_with_address_best_canvass_response_set_to "not_yet_visited"
-          expect(@address.reload.not_yet_visited?).to be true
+          expect(@address.reload.best_is_not_yet_visited?).to be true
         end
 
         it "should not be allowed for 'unknown'" do
           post_visit_with_address_best_canvass_response_set_to "unknown"
-          expect(@address.reload.unknown?).to be false
+          expect(@address.reload.best_is_unknown?).to be false
         end
 
         it "should not be allowed for 'strongly_for'" do
           post_visit_with_address_best_canvass_response_set_to "strongly_for"
-          expect(@address.reload.strongly_for?).to be false
+          expect(@address.reload.best_is_strongly_for?).to be false
         end
 
         it "should not be allowed for 'leaning_for'" do
           post_visit_with_address_best_canvass_response_set_to "leaning_for"
-          expect(@address.reload.leaning_for?).to be false
+          expect(@address.reload.best_is_leaning_for?).to be false
         end
 
         it "should not be allowed for 'undecided'" do
           post_visit_with_address_best_canvass_response_set_to "undecided"
-          expect(@address.reload.undecided?).to be false
+          expect(@address.reload.best_is_undecided?).to be false
         end
 
         it "should not be allowed for 'leaning_against'" do
           post_visit_with_address_best_canvass_response_set_to "leaning_against"
-          expect(@address.reload.leaning_against?).to be false
+          expect(@address.reload.best_is_leaning_against?).to be false
         end
 
         it "should not be allowed for 'strongly_against'" do
           post_visit_with_address_best_canvass_response_set_to "strongly_against"
-          expect(@address.reload.strongly_against?).to be false
+          expect(@address.reload.best_is_strongly_against?).to be false
         end
       end
 

--- a/spec/requests/api/visit_spec.rb
+++ b/spec/requests/api/visit_spec.rb
@@ -192,6 +192,7 @@ describe "Visit API" do
               expect(modified_person.address).to eq modified_address
               expect(modified_address.most_supportive_resident).to eq modified_person
               expect(modified_address.best_canvass_response).to eq modified_person.canvass_response
+              expect(modified_address.last_canvass_response).to eq modified_person.canvass_response
             end
           end
 
@@ -263,6 +264,7 @@ describe "Visit API" do
               expect(new_person.address).to eq modified_address
               expect(modified_address.most_supportive_resident).to eq new_person
               expect(modified_address.best_canvass_response).to eq new_person.canvass_response
+              expect(modified_address.last_canvass_response).to eq new_person.canvass_response
             end
           end
 
@@ -358,6 +360,7 @@ describe "Visit API" do
               expect(new_person.address).to eq modified_address
               expect(modified_address.most_supportive_resident).to eq new_person
               expect(modified_address.best_canvass_response).to eq new_person.canvass_response
+              expect(modified_address.last_canvass_response).to eq new_person.canvass_response
             end
           end
         end
@@ -511,6 +514,18 @@ describe "Visit API" do
         it "should not be allowed for 'strongly_against'" do
           post_visit_with_address_best_canvass_response_set_to "strongly_against"
           expect(@address.reload.strongly_against?).to be false
+        end
+      end
+
+      describe "allowed address attributes" do
+        it "allows setting 'address.last_canvass_response' directly" do
+          address = create(:address, id: 1)
+          authenticated_post "visits", {
+            data: { attributes: { duration_sec: 200 }, },
+            included: [ { id: 1, type: "addresses", attributes: { last_canvass_response: "not_yet_visited" } } ]
+          }, token
+
+          expect(Address.last.last_canvass_response).to eq "not_yet_visited"
         end
       end
     end

--- a/spec/serializers/address_serializer_spec.rb
+++ b/spec/serializers/address_serializer_spec.rb
@@ -69,6 +69,10 @@ describe AddressSerializer, :type => :serializer do
       it "has a 'best_canvass_response'" do
         expect(subject["best_canvass_response"]).to eql(resource.best_canvass_response)
       end
+
+      it "has a 'last_canvass_response'" do
+        expect(subject["last_canvass_response"]).to eql(resource.last_canvass_response)
+      end
     end
 
     context "relationships" do

--- a/spec/serializers/person_serializer_spec.rb
+++ b/spec/serializers/person_serializer_spec.rb
@@ -8,7 +8,7 @@ describe PersonSerializer, :type => :serializer do
         first_name: "Josh",
         last_name: "Smith",
         party_affiliation: "Democrat",
-        canvass_response: "Strongly for",
+        canvass_response: "strongly_for",
         previously_participated_in_caucus_or_primary: false,
         phone: "415-706-4899",
         email: "josh@coderly.com",


### PR DESCRIPTION
- [Asana task: Add last_canvass_response to address](https://app.asana.com/0/60127409159606/65925366411008)
- [Asana task: Make best_canvass_response actually exhibit the "best" response](https://app.asana.com/0/60127409159606/65925366411011)
# Description

This wasn't as simple as I thought it would be, I'm afraid.

It's not completely clear to me how the two fields should behave.

Before this PR, the behavior when creating a visit was:
- If there are people in the payload, we take the person with the highest support (in theory, there was a bug that made this not work). If that person has a higher rated `canvass_response` than the previous `best_canvass_response` of the address, that person was set to be the `most_supportive_resident` of the address and their `canvass_response` was set to be the addresses `best_canvass_response`
- If there are no people in the payload, but there is a `best_canvass_response` address parameter in the payload, which is also valid, then that value is set to be the `address.best_canvass_response`, as long as the address doesn't have a higher value from before. If the parameter is invalid, an error is raised.
- If there are no people in the payload and the `best_canvass_response` address parameter isn't present either, then we just set `address.best_canvass_response` to `:not_home` if there wasn't any previous value. 

With the new PR, the behavior is as follows:
- `best_canvass_response` behaves identically (except the bug was fixed)
- `last_canvass_response` is set to whichever of the following is available
  - Highest `canvass_response` of all the people in the payload (if there are people in the payload)
  - Value of the `last_canvass_response` address parameter if that parameter exists (unlike the `best_canvass_response` parameter, this one does not get validated, so we can set it to any value, this probably needs changing).
  - Value of the `best_canvass_response` address parameter if that parameter exists
  - "Unknown" is the default fallback

I'm not sure if this is the behavior we want, but it made the most sense to me.
## Bug that got fixed

I used 

``` Ruby
people.max { |person| person.canvas_response_rating| }.
```

To get the `most_supportive_resident`. `.max` is the wrong array function to use here and is being used incorrectly in general, causing that code to simply return the last element of the `people` array. The correct callback to use is `max_by` which is what we use now.
## There is no `last_canvass_response` enum, as there is a `best_canvas_response` enum.

The reason for that is that defining two enums with the same potential values is not possible (due to each enum defining a set of methods named after those values). My thinking is, we don't actually need it in this case.
## The code got complicated

I think that after merging this, or possibly even before, the create visit scenario should be reworked. There's a lot of jumping back and forth between code defined at the `Address` model level and the code in the `CreateVisit` scenario.

I think that, since most of it is related to visits specifically, most of it should go into the `CreateVisit` scenario. Once we have new types of actions (like phone calls), we can decide what belongs to the `Address` model and the individual scenarios.

If most of the current mode is moved into the scenario, it might allow us to simplify things a bit to.
