### PR TITLE
Removed deprecation

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,7 +28,7 @@ RSpec.configure do |config|
   config.include Paperclip::Shoulda::Matchers
 
   config.before(:each) do
-    Paperclip::Attachment.any_instance.stub(:save).and_return(true)
+    allow_any_instance_of(Paperclip::Attachment).to receive(:save).and_return(true)
   end
 
   config.after(:suite) do


### PR DESCRIPTION
- [Asana task: There is a deprecation warning for a Paperclip mock when running rspec](https://app.asana.com/0/60127409159606/67035908087735)
# Description

Missed it in the cloudfront PR. We were using `.stub` when we should have used `allow_any_instance_of(X)_to receive(:message).and_return(value)`.
