### PR TITLE
Fix/401 error format

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,10 @@ class ApplicationController < ActionController::API
 
   before_action :set_default_response_format
 
+  def doorkeeper_unauthorized_render_options(error: nil)
+    { json: ErrorSerializer.serialize(error) }
+  end
+
   def signed_in?
     current_user.present?
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 
 class UsersController < ApplicationController
-  before_filter :require_login, only: [:update, :me]
+  before_action :doorkeeper_authorize!, only: [:update, :me]
 
   def create
     if creating_with_facebook?

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -16,6 +16,8 @@ class ErrorSerializer
       return serialize_easypost_error(error) if error.class == EasyPost::Error
       return serialize_address_unmatched_error(error) if error.class == GroundGame::AddressUnmatched
       return serialize_facebook_authentication_error(error) if error.class == Koala::Facebook::AuthenticationError
+      return serialize_doorkeeper_oauth_invalid_token_response(error) if error.class == Doorkeeper::OAuth::InvalidTokenResponse
+      return serialize_doorkeeper_oauth_error_response(error) if error.class == Doorkeeper::OAuth::ErrorResponse
     end
 
     def self.serialize_argument_error(error)
@@ -78,6 +80,24 @@ class ErrorSerializer
         title: "Facebook authentication error",
         detail: error.fb_error_message,
         status: error.http_status
+      }
+    end
+
+    def self.serialize_doorkeeper_oauth_invalid_token_response(error)
+      return {
+        id: "NOT_AUTHORIZED",
+        title: "Not authorized",
+        detail: error.description,
+        status: 401
+      }
+    end
+
+    def self.serialize_doorkeeper_oauth_error_response(error)
+      return {
+        id: "INVALID_GRANT",
+        title: "Invalid grant",
+        detail: error.description,
+        status: 401
       }
     end
 end

--- a/spec/lib/ground_game/scenario/create_visit_spec.rb
+++ b/spec/lib/ground_game/scenario/create_visit_spec.rb
@@ -346,10 +346,8 @@ module GroundGame
 
               error = CreateVisit.new(visit_params, address_params, people_params, user).call.error
 
-              expect(error.id).to eq "ARGUMENT_ERROR"
-              expect(error.title).to eq "Argument error"
-              expect(error.detail).to eq "'invalid response' is not a valid canvass_response"
-              expect(error.status).to eq 422
+              expect(error.class).to eq ScenarioError
+              expect(error.hash).to be_a_valid_json_api_error.with_id "ARGUMENT_ERROR"
             end
 
             it "handles ActiveRecord::RecordNotFound with code 404" do
@@ -359,10 +357,8 @@ module GroundGame
 
               error = CreateVisit.new(visit_params, address_params, people_params, user).call.error
 
-              expect(error.id).to eq "RECORD_NOT_FOUND"
-              expect(error.title).to eq "Record not found"
-              expect(error.detail).to eq "Couldn't find Address with 'id'=11"
-              expect(error.status).to eq 404
+              expect(error.class).to eq ScenarioError
+              expect(error.hash).to be_a_valid_json_api_error.with_id "RECORD_NOT_FOUND"
             end
 
             it "handles GroundGame::VisitNotAllowedError with code 403" do
@@ -374,10 +370,8 @@ module GroundGame
 
               error = CreateVisit.new(visit_params, address_params, people_params, user).call.error
 
-              expect(error.id).to eq "VISIT_NOT_ALLOWED"
-              expect(error.title).to eq "Visit not allowed"
-              expect(error.detail).to eq "You can't submit the same address so quickly after it was last visited."
-              expect(error.status).to eq 403
+              expect(error.class).to eq ScenarioError
+              expect(error.hash).to be_a_valid_json_api_error.with_id "VISIT_NOT_ALLOWED"
             end
 
             it "handles GroundGame::InvalidBestCanvassResponse with code 422" do
@@ -387,10 +381,8 @@ module GroundGame
 
               error = CreateVisit.new(visit_params, address_params, people_params, user).call.error
 
-              expect(error.id).to eq "INVALID_BEST_CANVASS_RESPONSE"
-              expect(error.title).to eq "Invalid best canvass response"
-              expect(error.detail).to eq "Invalid argument 'strongly_for' for address.best_canvass_response"
-              expect(error.status).to eq 422
+              expect(error.class).to eq ScenarioError
+              expect(error.hash).to be_a_valid_json_api_error.with_id "INVALID_BEST_CANVASS_RESPONSE"
             end
           end
 

--- a/spec/lib/ground_game/scenario/match_address_spec.rb
+++ b/spec/lib/ground_game/scenario/match_address_spec.rb
@@ -65,10 +65,10 @@ module GroundGame
 
             result = MatchAddress.new(address_params).call
 
+
             expect(result.success?).to be false
-            expect(result.error.status).to eq 404
-            expect(result.error.detail).to eq "The requested address does not exist in the database."
-            expect(result.address).to be_nil
+            expect(result.error.class).to eq ScenarioError
+            expect(result.error.hash).to be_a_valid_json_api_error.with_id "ADDRESS_UNMATCHED"
           end
 
           it "handles an EasyPost::Error" do
@@ -81,9 +81,8 @@ module GroundGame
               result = MatchAddress.new(address_params).call
 
               expect(result.success?).to be false
-              expect(result.error.status).to eq 400
-              expect(result.error.detail).to eq "Insufficient address data provided. A city and state or a zip must be provided."
-              expect(result.address).to be_nil
+              expect(result.error.class).to eq ScenarioError
+              expect(result.error.hash).to be_a_valid_json_api_error.with_id "EASYPOST_ERROR"
             end
 
 
@@ -96,9 +95,8 @@ module GroundGame
               result = MatchAddress.new(address_params).call
 
               expect(result.success?).to be false
-              expect(result.error.status).to eq 400
-              expect(result.error.detail).to eq "Insufficient address data provided. A street must be provided."
-              expect(result.address).to be_nil
+              expect(result.error.class).to eq ScenarioError
+              expect(result.error.hash).to be_a_valid_json_api_error.with_id "EASYPOST_ERROR"
             end
           end
         end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,7 +42,6 @@ RSpec.configure do |config|
     end
   end
 
-
   def host
     "http://api.lvh.me:3000"
   end

--- a/spec/requests/api/address_spec.rb
+++ b/spec/requests/api/address_spec.rb
@@ -6,6 +6,7 @@ describe "Address API" do
     it "requires authentication" do
       get "#{host}/addresses"
       expect(last_response.status).to eq 401
+      expect(json).to be_a_valid_json_api_error.with_id "NOT_AUTHORIZED"
     end
 
     context "when authenticated" do

--- a/spec/requests/api/address_spec.rb
+++ b/spec/requests/api/address_spec.rb
@@ -42,12 +42,7 @@ describe "Address API" do
           }, token
 
           expect(last_response.status).to eq 404
-          expect(json.errors.length).to eq 1
-          error = json.errors.first
-          expect(error.id).to eq "ADDRESS_UNMATCHED"
-          expect(error.title).to eq "Address unmatched"
-          expect(error.detail).to eq "The requested address does not exist in the database."
-          expect(error.status).to eq 404
+          expect(json).to be_a_valid_json_api_error.with_id "ADDRESS_UNMATCHED"
         end
 
         it "returns an existing address with people included if the address exists", vcr: { cassette_name: "requests/api/addresses/succesful_easypost_response" } do

--- a/spec/requests/api/ranking_spec.rb
+++ b/spec/requests/api/ranking_spec.rb
@@ -5,6 +5,7 @@ describe "Rankings API" do
     it "requires authentication" do
       get "#{host}/rankings"
       expect(last_response.status).to eq 401
+      expect(json).to be_a_valid_json_api_error.with_id "NOT_AUTHORIZED"
     end
 
     context "when authenticated" do

--- a/spec/requests/api/tokens_spec.rb
+++ b/spec/requests/api/tokens_spec.rb
@@ -27,7 +27,7 @@ describe "Tokens API" do
         }
 
         expect(last_response.status).to eq 401
-        expect(json.error).to eq 'invalid_grant'
+        expect(json).to be_a_valid_json_api_error.with_id "INVALID_GRANT"
       end
 
       it "fails with 401 when password is invalid" do
@@ -38,7 +38,7 @@ describe "Tokens API" do
         }
 
         expect(last_response.status).to eq 401
-        expect(json.error).to eq 'invalid_grant'
+        expect(json).to be_a_valid_json_api_error.with_id "INVALID_GRANT"
       end
 
       describe "automatic leaderboard update" do

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -493,6 +493,7 @@ describe "Users API" do
       }
 
       expect(last_response.status).to eq 401
+      expect(json).to be_a_valid_json_api_error.with_id "NOT_AUTHORIZED"
     end
 
     it 'successfully updates yourself when you are logged in' do
@@ -618,6 +619,7 @@ describe "Users API" do
     it 'should return unauthorized if not logged in' do
       get "#{host}/users/me"
       expect(last_response.status).to eq 401
+      expect(json).to be_a_valid_json_api_error.with_id "NOT_AUTHORIZED"
     end
 
     it 'should return the correct data if logged in' do

--- a/spec/requests/api/visit_spec.rb
+++ b/spec/requests/api/visit_spec.rb
@@ -5,6 +5,7 @@ describe "Visit API" do
     it "requires authentication" do
       post "#{host}/visits"
       expect(last_response.status).to eq 401
+      expect(json).to be_a_valid_json_api_error.with_id "NOT_AUTHORIZED"
     end
 
     context "when authenticated" do

--- a/spec/requests/api/visit_spec.rb
+++ b/spec/requests/api/visit_spec.rb
@@ -511,12 +511,7 @@ describe "Visit API" do
             included: [ { type: "addresses", id: 1, attributes: { } }, { type: "people", id: 10, attributes: {} } ]
           }, token
           expect(last_response.status).to eq 404
-          expect(json.errors.length).to eq 1
-          error = json.errors.first
-          expect(error.id).to eq "RECORD_NOT_FOUND"
-          expect(error.title).to eq "Record not found"
-          expect(error.detail).to eq "Couldn't find Person with 'id'=10"
-          expect(error.status).to eq 404
+          expect(json).to be_a_valid_json_api_error.with_id "RECORD_NOT_FOUND"
         end
       end
 

--- a/spec/serializers/error_serializer_spec.rb
+++ b/spec/serializers/error_serializer_spec.rb
@@ -97,5 +97,33 @@ describe ErrorSerializer do
       expect(error[:detail]).to eq "A message"
       expect(error[:status]).to eq 400
     end
+
+    it "can serialize Doorkeeper::OAuth::InvalidTokenResponse" do
+      error = Doorkeeper::OAuth::InvalidTokenResponse.new
+      result = ErrorSerializer.serialize(error)
+
+      expect(result[:errors]).not_to be_nil
+      expect(result[:errors].length).to eq 1
+
+      error = result[:errors].first
+      expect(error[:id]).to eq "NOT_AUTHORIZED"
+      expect(error[:title]).to eq "Not authorized"
+      expect(error[:detail]).to eq "The access token is invalid"
+      expect(error[:status]).to eq 401
+    end
+
+    it "can serialize Doorkeeper::OAuth::ErrorResponse" do
+      error = Doorkeeper::OAuth::ErrorResponse.new name: "invalid_grant"
+      result = ErrorSerializer.serialize(error)
+
+      expect(result[:errors]).not_to be_nil
+      expect(result[:errors].length).to eq 1
+
+      error = result[:errors].first
+      expect(error[:id]).to eq "INVALID_GRANT"
+      expect(error[:title]).to eq "Invalid grant"
+      expect(error[:detail]).to eq "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."
+      expect(error[:status]).to eq 401
+    end
   end
 end

--- a/spec/support/helpers/error_format_helpers.rb
+++ b/spec/support/helpers/error_format_helpers.rb
@@ -1,0 +1,37 @@
+RSpec::Matchers.define :be_a_valid_json_api_error do
+  def hash_has_nonempty_error_key?
+    return false unless @hash.has_key? :errors
+    return false unless @hash[:errors].class == Array
+    return false unless @hash[:errors].length > 0
+    return true
+  end
+
+  def all_errors_in_hash_are_valid?
+    return false unless @hash[:errors].all? { |error| is_valid? error }
+    return true
+  end
+
+  def is_valid?(error)
+    error = error.with_indifferent_access
+    return false unless error.has_key? :id
+    return false unless error.has_key? :title
+    return false unless error.has_key? :detail
+    return false unless error.has_key? :status
+    return true
+  end
+
+  def id_is_correct
+    @hash[:errors].first[:id] == @expected_id
+  end
+
+  match do |hash|
+    @hash = hash.with_indifferent_access
+    result = hash_has_nonempty_error_key? and all_errors_in_hash_are_valid?
+    result &&= id_is_correct unless @expected_id.nil?
+    result
+  end
+
+  chain :with_id do |expected_id|
+    @expected_id = expected_id
+  end
+end


### PR DESCRIPTION
- [Asana task: 401 json body doesn't follow other errors](https://app.asana.com/0/60127409159606/66631982431335)
# Description

There are two different cases for this error was happening, so I had to handle both of them.
- One of them is simply when attempting to access a protected endpoint while unauthenticated.
  - For all but one of the cases, it was just a matter defining a `doorkeeper_unauthorized_render_options` method in the application controller
  - For one case, in the `users_controller`, we were using a `before_filter: :require_login` instead of the standard `before_action: :doorkeeper_authorize!`, so I had to change that.
- The other is in the tokens controller, when attempting to log in with bad credentials. In this case, I had to create a controller-specific solution.
## New custom matcher

While implementing this, I noticed a lot of code repetition when testing for errors, so I created an rspec matcher to quickly check the error format is valid.

``` Ruby
# usage
expect(json).to be_a_valid_json_api_error
# optional chaining
expect(json).to be_a_valid_json_api_error.with_id "EXPECTED_ID"
```
