### PR TITLE
Added inclusion of error code into EasyPost Error serialization

### DIFF
--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -1,5 +1,6 @@
 require "ground_game/errors/visit_not_allowed"
 require "ground_game/errors/invalid_best_canvass_response"
+require "ground_game/easypost_error_adapter"
 
 class ErrorSerializer
   def self.serialize(error)
@@ -55,14 +56,12 @@ class ErrorSerializer
     end
 
     def self.serialize_easypost_error(error)
-      ep_code = error.code
-      friendly_code = ep_code.gsub(".", " ").capitalize
-      id_code = ep_code.gsub(".", "_")
+      adapted_error = GroundGame::EasyPostErrorAdapter.new(error)
       return {
-        id: "EASYPOST_ERROR_#{id_code}",
-        title: "Easypost: #{friendly_code}",
-        detail: error.message,
-        status: error.http_status
+        id: adapted_error.id,
+        title: adapted_error.title,
+        detail: adapted_error.detail,
+        status: adapted_error.status
       }
     end
 

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -55,9 +55,12 @@ class ErrorSerializer
     end
 
     def self.serialize_easypost_error(error)
+      ep_code = error.code
+      friendly_code = ep_code.gsub(".", " ").capitalize
+      id_code = ep_code.gsub(".", "_")
       return {
-        id: "EASYPOST_ERROR",
-        title: "Easypost error",
+        id: "EASYPOST_ERROR_#{id_code}",
+        title: "Easypost: #{friendly_code}",
         detail: error.message,
         status: error.http_status
       }

--- a/lib/ground_game/easypost_error_adapter.rb
+++ b/lib/ground_game/easypost_error_adapter.rb
@@ -1,0 +1,51 @@
+module GroundGame
+  class EasyPostErrorAdapter
+
+    attr_reader :detail, :id, :title, :status
+
+    def initialize(error)
+      @error = error
+      @detail = compute_detail
+      @id = compute_id
+      @title = compute_title
+      @status = compute_status
+    end
+
+    private
+      def compute_detail
+        message = @error.message
+        LEADING_STRINGS_TO_REMOVE.each do |string|
+          message.sub!(string + ": ", "")
+        end
+        message
+      end
+
+      LEADING_STRINGS_TO_REMOVE = [
+        "Default address"
+      ]
+
+      CODE_TO_ID = {
+        "ADDRESS.VERIFY.FAILURE" => "EASYPOST_ADDRESS_VERIFICATION_ERROR"
+      }
+
+      UNKNOWN_ID = "EASYPOST_UNKNOWN_ERROR"
+
+      def compute_id
+        CODE_TO_ID[@error.code] || UNKNOWN_ID
+      end
+
+      CODE_TO_TITLE = {
+        "ADDRESS.VERIFY.FAILURE" => "Unable to verify address"
+      }
+
+      UNKNOWN_TITLE = "Unknown address error"
+
+      def compute_title
+        CODE_TO_TITLE[@error.code] || UNKNOWN_TITLE
+      end
+
+      def compute_status
+        @error.http_status
+      end
+  end
+end

--- a/lib/ground_game/errors/visit_not_allowed.rb
+++ b/lib/ground_game/errors/visit_not_allowed.rb
@@ -4,6 +4,6 @@ module GroundGame
       super ERROR_MESSAGE
     end
     private
-      ERROR_MESSAGE = "You can't submit the same address so quickly after it was last visited."
+      ERROR_MESSAGE = "You can't canvass the same address so soon after it was last canvassed."
   end
 end

--- a/spec/lib/ground_game/scenario/create_visit_spec.rb
+++ b/spec/lib/ground_game/scenario/create_visit_spec.rb
@@ -376,7 +376,7 @@ module GroundGame
 
               expect(error.id).to eq "VISIT_NOT_ALLOWED"
               expect(error.title).to eq "Visit not allowed"
-              expect(error.detail).to eq "You can't submit the same address so quickly after it was last visited."
+              expect(error.detail).to eq "You can't canvass the same address so soon after it was last canvassed."
               expect(error.status).to eq 403
             end
 

--- a/spec/lib/ground_game/scenario/match_address_spec.rb
+++ b/spec/lib/ground_game/scenario/match_address_spec.rb
@@ -82,8 +82,8 @@ module GroundGame
 
               expect(result.success?).to be false
               expect(result.error.status).to eq 400
-              expect(result.error.id).to eq "EASYPOST_ERROR_ADDRESS_VERIFY_FAILURE"
-              expect(result.error.title).to eq "Easypost: Address verify failure"
+              expect(result.error.id).to eq "EASYPOST_ADDRESS_VERIFICATION_ERROR"
+              expect(result.error.title).to eq "Unable to verify address"
               expect(result.error.detail).to eq "Insufficient address data provided. A city and state or a zip must be provided."
               expect(result.address).to be_nil
             end
@@ -101,8 +101,8 @@ module GroundGame
 
               expect(result.success?).to be false
               expect(result.error.status).to eq 400
-              expect(result.error.id).to eq "EASYPOST_ERROR_ADDRESS_VERIFY_FAILURE"
-              expect(result.error.title).to eq "Easypost: Address verify failure"
+              expect(result.error.id).to eq "EASYPOST_ADDRESS_VERIFICATION_ERROR"
+              expect(result.error.title).to eq "Unable to verify address"
               expect(result.error.detail).to eq "Insufficient address data provided. A street must be provided."
               expect(result.address).to be_nil
             end
@@ -121,9 +121,9 @@ module GroundGame
 
               expect(result.success?).to be false
               expect(result.error.status).to eq 400
-              expect(result.error.id).to eq "EASYPOST_ERROR_ADDRESS_VERIFY_FAILURE"
-              expect(result.error.title).to eq "Easypost: Address verify failure"
-              expect(result.error.detail).to eq "Default address: The address you entered was found but more information is needed (such as an apartment, suite, or box number) to match to a specific address."
+              expect(result.error.id).to eq "EASYPOST_ADDRESS_VERIFICATION_ERROR"
+              expect(result.error.title).to eq "Unable to verify address"
+              expect(result.error.detail).to eq "The address you entered was found but more information is needed (such as an apartment, suite, or box number) to match to a specific address."
               expect(result.address).to be_nil
             end
           end

--- a/spec/serializers/error_serializer_spec.rb
+++ b/spec/serializers/error_serializer_spec.rb
@@ -39,7 +39,7 @@ describe ErrorSerializer do
       error = result[:errors].first
       expect(error[:id]).to eq "VISIT_NOT_ALLOWED"
       expect(error[:title]).to eq "Visit not allowed"
-      expect(error[:detail]).to eq "You can't submit the same address so quickly after it was last visited."
+      expect(error[:detail]).to eq "You can't canvass the same address so soon after it was last canvassed."
       expect(error[:status]).to eq 403
     end
 

--- a/spec/serializers/error_serializer_spec.rb
+++ b/spec/serializers/error_serializer_spec.rb
@@ -70,15 +70,15 @@ describe ErrorSerializer do
     end
 
     it "can serialize EasyPost::Error" do
-      easypost_error = EasyPost::Error.new("A message", 400)
+      easypost_error = EasyPost::Error.new("A message", 400, nil, { error: { code: "A.CODE"}})
       result = ErrorSerializer.serialize(easypost_error)
 
       expect(result[:errors]).not_to be_nil
       expect(result[:errors].length).to eq 1
 
       error = result[:errors].first
-      expect(error[:id]).to eq "EASYPOST_ERROR"
-      expect(error[:title]).to eq "Easypost error"
+      expect(error[:id]).to eq "EASYPOST_ERROR_A_CODE"
+      expect(error[:title]).to eq "Easypost: A code"
       expect(error[:detail]).to eq "A message"
       expect(error[:status]).to eq 400
     end

--- a/spec/serializers/error_serializer_spec.rb
+++ b/spec/serializers/error_serializer_spec.rb
@@ -77,8 +77,8 @@ describe ErrorSerializer do
       expect(result[:errors].length).to eq 1
 
       error = result[:errors].first
-      expect(error[:id]).to eq "EASYPOST_ERROR_A_CODE"
-      expect(error[:title]).to eq "Easypost: A code"
+      expect(error[:id]).to eq "EASYPOST_UNKNOWN_ERROR"
+      expect(error[:title]).to eq "Unknown address error"
       expect(error[:detail]).to eq "A message"
       expect(error[:status]).to eq 400
     end

--- a/spec/vcr/lib/ground_game/scenario/match_address/failed_easypost_request_not_specific_enough.yml
+++ b/spec/vcr/lib/ground_game/scenario/match_address/failed_easypost_request_not_specific_enough.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses/create_and_verify
+    body:
+      encoding: US-ASCII
+      string: address[street1]=4166%20Wilson%20Ave&address[city]=San%20Diego&address[state]=CA&address[zip]=92104
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.1.8
+      Authorization:
+      - Bearer EASYPOST_API_KEY
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '99'
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Fri, 20 Nov 2015 19:59:40 GMT
+      Status:
+      - 400 Bad Request
+      Connection:
+      - close
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 2fa308ee-3aed-4fe3-93d8-c7cb64088586
+      X-Runtime:
+      - '0.597752'
+      X-Node:
+      - web4sj, 6427aa0e60
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb5sj, da774e7ae0
+      Strict-Transport-Security:
+      - max-age=86400
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"ADDRESS.VERIFY.FAILURE","message":"Default address:
+        The address you entered was found but more information is needed (such as
+        an apartment, suite, or box number) to match to a specific address.","errors":[]}}'
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 19:59:38 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
- [Asana task: Transform Easypost error into a better error](https://app.asana.com/0/42698431045490/67550233260346)
# Description

An attempt to add more information into an EasyPost error by using the error code (which is something along the lines of a JSON API error ID).

However, I'm not completely sure this is something that fixes the specific issue described in the task. I could not produce an EasypostAPI error response which returns an error with ""Default address." as the message.

In order to add more detail to that one, I need more information to reproduce it.
