### PR TITLE
Fix/leaderboards not getting updated

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,12 +45,12 @@ class UsersController < ApplicationController
 
     if user.save
       InitializeNewFacebookUserWorker.perform_async(user.id)
+
       if photo_param?
         UpdateProfilePictureWorker.perform_async(user.id)
       else
         AddFacebookProfilePicture.perform_async(user.id)
       end
-      UpdateUsersLeaderboardsWorker.perform_async(user.id)
 
       render json: user
     else

--- a/lib/ground_game/scenario/update_friends_leaderboards.rb
+++ b/lib/ground_game/scenario/update_friends_leaderboards.rb
@@ -6,10 +6,15 @@ module GroundGame
       def initialize(user)
         @user = user
         @followers = user.followers
+        @following = user.following
       end
 
       def call
         @followers.each do |friend|
+          GroundGame::Scenario::UpdateUsersFriendLeaderboard.new(friend, @user).call
+        end
+
+        @following.each do |friend|
           GroundGame::Scenario::UpdateUsersFriendLeaderboard.new(friend, @user).call
         end
       end

--- a/lib/ground_game/scenario/update_leaderboards.rb
+++ b/lib/ground_game/scenario/update_leaderboards.rb
@@ -1,3 +1,5 @@
+require 'ground_game/scenario/update_users_friend_leaderboard'
+
 module GroundGame
   module Scenario
     class UpdateLeaderboards
@@ -7,8 +9,12 @@ module GroundGame
 
       def call
         everyone_leaderboard.rank_user(@user)
-        friends_leaderboard.rank_user(@user)
         state_leaderboard.rank_user(@user) if @user.state_code
+
+        friends_leaderboard.rank_user(@user)
+        @user.followers.each do |friend|
+          friends_leaderboard.rank_user(friend)
+        end
       end
 
       private

--- a/lib/ground_game/scenario/update_users_friend_leaderboard.rb
+++ b/lib/ground_game/scenario/update_users_friend_leaderboard.rb
@@ -1,23 +1,26 @@
 module GroundGame
   module Scenario
     class UpdateUsersFriendLeaderboard
-      def initialize(friend, user)
-        @user = user
-        @friend = friend
+      def initialize(leaderboard_owner, user_to_rank)
+        @user_to_rank = user_to_rank
+        @leaderboard_owner = leaderboard_owner
       end
 
       def call
-        old_friend_rank = friends_leaderboard.check_user_rank(@friend)
-        friends_leaderboard.rank_user(@user)
-        new_friend_rank = friends_leaderboard.check_user_rank(@friend)
-        rank_changed = old_friend_rank != new_friend_rank
-        NotifyUserOfChangedRankWorker.perform_async(@friend.id, @user.id) if rank_changed
+        old_owner_rank = leaderboard.check_user_rank(@leaderboard_owner)
+
+        leaderboard.rank_user(@user_to_rank)
+
+        new_owner_rank = leaderboard.check_user_rank(@leaderboard_owner)
+        owner_rank_changed = old_owner_rank != new_owner_rank
+
+        NotifyUserOfChangedRankWorker.perform_async(@leaderboard_owner.id, @user_to_rank.id) if owner_rank_changed
       end
 
       private
 
-      def friends_leaderboard
-        @friends_leaderboard ||= UserLeaderboard.for_friend_list_of_user(@friend)
+      def leaderboard
+        @leaderboard ||= UserLeaderboard.for_friend_list_of_user(@leaderboard_owner)
       end
     end
   end

--- a/spec/lib/ground_game/scenario/update_friends_leaderboards_spec.rb
+++ b/spec/lib/ground_game/scenario/update_friends_leaderboards_spec.rb
@@ -9,14 +9,25 @@ module GroundGame
 
         before do
           @user = create(:user, id: 10)
-          users_friends = create_list(:user, 5)
-          users_friends.each { |friend| friend.follow(@user) }
+          followers = create_list(:user, 5)
+          followers.each { |friend| friend.follow(@user) }
+          following = create_list(:user, 5)
+          following.each { |friend| @user.follow(friend) }
         end
 
-        it "updates each of the user's friend's 'friends' leaderboard" do
+        it "updates each of the user's followers's 'friends' leaderboard" do
           UpdateFriendsLeaderboards.new(@user).call
 
           @user.followers.each do |follower|
+            follower_friend_leaderboard = Ranking.for_friend_list(list_owner: follower, id: @user.id)
+            expect(follower_friend_leaderboard.length).to eq 1
+          end
+        end
+
+        it "updates each of the user's following's 'friends' leaderboard" do
+          UpdateFriendsLeaderboards.new(@user).call
+
+          @user.following.each do |follower|
             follower_friend_leaderboard = Ranking.for_friend_list(list_owner: follower, id: @user.id)
             expect(follower_friend_leaderboard.length).to eq 1
           end

--- a/spec/lib/ground_game/scenario/update_leaderboards_spec.rb
+++ b/spec/lib/ground_game/scenario/update_leaderboards_spec.rb
@@ -11,38 +11,36 @@ module GroundGame
 
           before do
             @user = create(:user, id: 10, email: "test-user@mail.com", password: "password", state_code: "NY")
-
-            # I would love to somehow have this work with factory_girl or something similar, but I'm not sure how
-
-            everyone = UserLeaderboard.for_everyone
-            3.times { |n| everyone.rank_member(n.to_s, n) }
-
-            state_ny = UserLeaderboard.for_state("NY")
-            2.times { |n| state_ny.rank_member(n.to_s, n) }
-
-            friends = UserLeaderboard.for_friend_list_of_user(@user)
-            5.times { |n| friends.rank_member(n.to_s, n) }
           end
 
           it "updates the 'everyone' leaderboard" do
+            everyone = UserLeaderboard.for_everyone
+            3.times { |n| everyone.rank_member(n.to_s, n) }
+
             UpdateLeaderboards.new(@user).call
 
             everyone_rankings = Ranking.for_everyone(id: 10)
-            expect(everyone_rankings.length).to eq 4
+            expect(everyone_rankings.length).to eq 4 # 3 from before plus 1 new
           end
 
           it "updates the user's 'state' leaderboard" do
+            state_ny = UserLeaderboard.for_state("NY")
+            2.times { |n| state_ny.rank_member(n.to_s, n) }
+
             UpdateLeaderboards.new(@user).call
 
             ny_rankings = Ranking.for_state(id: 10, state_code: "NY")
-            expect(ny_rankings.length).to eq 3
+            expect(ny_rankings.length).to eq 3 # 2 from before plus 1 new
           end
 
           it "updates the user's 'friends' leaderboard" do
+            followers = create_list(:user, 5)
+            followers.each { |follower| follower.follow(@user) }
+
             UpdateLeaderboards.new(@user).call
 
             friend_rankings = Ranking.for_user_in_users_friend_list(user: @user)
-            expect(friend_rankings.length).to eq 6
+            expect(friend_rankings.length).to eq 6 # 5 followers plus user
           end
         end
 


### PR DESCRIPTION
- [Asana task: Fix bug with friend leaderboards not showing up](https://app.asana.com/0/42698431045490/64714376827791)
# Description

This is a partial fix, since it seems we might be ignoring one part of the leaderboard concept. The description is long, but most of it is recapped in the final two sections (Conclusion and Solution).

I had to dig deep into this to figure it out, so here are my findings...

Two scenarios deal with leaderboards:
- `GroundGame::Scenario::UpdateLeaderboards`
- `GroundGame::Scenario::UpdateFriendsLeaderboards`

Both are called one right after the other (in order listed), from the `UpdateUsersLeaderboardsWorker`, meaning the only time leaderboards are touched is when this worker is asked to perform.

The worker is called in the following situations
- When a user logs in
- After creating a user through facebook (this is a bug, should not be called here directly)
- From `InitializeNewFacebookUserWorker` **after** we follow all of the user's friends by the created user, and have the created user's friends follow him.
- After creating a user the regular way (this one is ok, not a bug, since no friends have to be added)
- When a visit is successfully saved
# Creating a facebook user

Let's say there's Mike from New York, who has Dana as a facebook friend. They register into our app through facebook.

Mike gets an account, Dana is already in the database
## When Mike registers
- Mike follows Dana automatically, 
- Dana follows Mike automatically
- "everyone" leaderboard updates, Mike gets ranked on it, Dana does not.
- "state_NY" leadearboard updates, Mike gets ranked on it, Dana does not.
- "mike_id_friends" gets updated. Mike gets ranked on it, Dana does not.
- Dana is Mikes's follower, so "dana_id_friends" gets updated. Mike gets ranked on it, Dana does not.

**Leaderboards**:
- "everyone", containing Mike
- "state_ny", containing Mike
- "mike_id_friends", containing Mike
- "dana_id_friends", containing Mike
## When Mike logs in

Same thing as when registering happens, except creating new relationships. Leaderboard contents remain the same.
## When Mike submits a visit

Same thing happens again, Leaderboard contents are the same.
## When Dana logs in
- "everyone" leaderboard updates, Dana gets ranked on it, Mike does not.
- "state_danas_state" leadearboard updates, Dana gets ranked on it, Mike does not.
- "dana_id_friends" gets updated. Dana gets ranked on it, Mike does not.
- Mike is Danas's follower, so "mike_id_friends" gets updated. Dana gets ranked on it, Mike does not.

**Leaderboards**:
- "everyone", containing Mike and Dana, in some order
- "state_ny", containing Mike
- "state_danas_state", containing Dana.
- "mike_id_friends", containing Mike and Dana, in some order
- "dana_id_friends", containing Mike and Dana, in some order
## When Dana submits a visit

Same thing happens as when she logs in. Leadeboard contets are the same, except maybe the order.
# For regular user
- Dana is already in the database
- Mike registers and ends up following Dana at some point (bot not the other way around)
## When Mike registers
- "everyone" leaderboard updates, Mike gets ranked on it, Dana does not.
- "state_NY" leadearboard updates, Mike gets ranked on it, Dana does not.
- "mike_id_friends" gets updated. Mike gets ranked on it, Dana does not.
- Dana is **not Mike's follower', Mike is following Dana only, so "dana_id_friends"  does not get updated.

**Leaderboards**
- "everyone", containing Mike
- "state_ny", containing Mike
- "mike_id_friends" containing Mike
## When Mike logs in or submits a visit, same things happen, leaderboards Don't change.
## When Dana logs in
- "everyone" leaderboard updates, Dana gets ranked on it, Mike does not.
- "state_danas_state" leadearboard updates, Dana gets ranked on it, Mike does not.
- "dana_id_friends" gets updated. Dana gets ranked on it, Mike does not.
- Mike is Dana's follower', so "mike_id_friends" gets updated. Dana gets ranked on it.

**Leaderboards**
- "everyone", containing Mike and Dana.
- "state_ny", containing Mike.
- "state_danas_state", containing Dana.
- "mike_id_friends", containing Mike and Dana.
- "dana_id_friends", containing Dana only.
# Conclusion
- There is a minor bug where the worker is called ouside of the regular flow when registering a facebook user. This line can be removed, but does not really affect the outcome of anything, just does extra, unnecesary work.
- The problem with friend lists not being updated in general is twofold:
  - A user gets updated on the "everyone", "state", their "user_id_friends" leaderboards or "follower_id_friends" leaderboards of each of their followers **only when they register, log in or submit a visit, not when one of their followers does it**
  - When a user registers, logs in, or submits a visit, they update the "everyone", "state", "user_id_friends" leaderboards as well as "follower_id_friends" lists for each of their followers, but they do not update "followed_id_friends" leaderboards for any of the people they themselves are following.
  - The user's friend list, even when all is done and fixed, contains the user themselves, and the people that follow this user. **The user has no information about the people they follow.**
# Solution
## **So the actual problems are**
- [x] **There is some additional unnecessary work being done**. This is easily fixed by removing that line.
- [x] **When I register, my friend list will only contain me, until the people that follow me start doing something. Even if they did something before, I can't see it until they do something else.** The solution for this is to go through the list of my followers and rank them on my friend list. It requires additional work, but is a relatively easy change and is not a lot of work.
- [x] **When I do anything that updates leaderboards, my followers will get that information, but the people I'm following will not. This is wrong, because the people I'm following have me on their friends list, so they need to know**. The solution for this would be, to go through the list of people I'm following and update myself on their friends list. That way, when I do something, people that have me on their friend list will know.
- [ ] **The friend list might contain the wrong people in general**. Not sure how to handle this. Most straighforward would be to have "user_id_following" and "user_id_followers" leaderboards instead of "user_id_friends" (which is actualy just "user_id_followers" to begin with).
## Worries

I say it's not a lot of additional work to fix this, but there might be an issue. We compute the score for the past week, so for each new ranking, it looks like there may be additional queries to the visits table. I'm not sure how that works internally.
