### PR TITLE
Add last visited by

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -15,14 +15,14 @@ class AddressesController < ApplicationController
 
     def match_addresses_using_radius
       addresses = Address.within(index_params[:radius], origin: [index_params[:latitude], index_params[:longitude]])
-                         .includes([:most_supportive_resident, :people])
-      render json: addresses
+                         .includes([:most_supportive_resident, :people, :last_visited_by])
+      render json: addresses, include: ['last_visited_by']
     end
 
     def match_address_using_search_parameters
       result = GroundGame::Scenario::MatchAddress.new(search_params).call
       if result.success?
-        render json: [result.address], include: ['people']
+        render json: [result.address], include: ['people', 'last_visited_by']
       else
         render json: result.error.hash, status: result.error.status
       end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -4,6 +4,7 @@ require "ground_game/errors/visit_not_allowed"
 class Address < ActiveRecord::Base
   has_many :people
   belongs_to :most_supportive_resident, class_name: "Person"
+  belongs_to :last_visited_by, class_name: "User"
 
   acts_as_mappable :default_units => :meters,
                    :default_formula => :sphere,

--- a/app/serializers/address_serializer.rb
+++ b/app/serializers/address_serializer.rb
@@ -3,5 +3,6 @@ class AddressSerializer < ActiveModel::Serializer
     :zip_code, :visited_at, :best_canvass_response, :last_canvass_response
 
   belongs_to :most_supportive_resident
+  belongs_to :last_visited_by
   has_many :people
 end

--- a/db/migrate/20151123090947_add_last_visited_by_to_address.rb
+++ b/db/migrate/20151123090947_add_last_visited_by_to_address.rb
@@ -1,5 +1,13 @@
 class AddLastVisitedByToAddress < ActiveRecord::Migration
   def change
     add_column :addresses, :last_visited_by_id, :integer
+
+    Address.all.each do |address|
+      visits = AddressUpdate.where(address: address).map(&:visit)
+      if visits.length > 0
+        latest_visit = visits.sort_by{ |visit| visit.updated_at }.last
+        address.update(last_visited_by: latest_visit.user)
+      end
+    end
   end
 end

--- a/db/migrate/20151123090947_add_last_visited_by_to_address.rb
+++ b/db/migrate/20151123090947_add_last_visited_by_to_address.rb
@@ -1,0 +1,5 @@
+class AddLastVisitedByToAddress < ActiveRecord::Migration
+  def change
+    add_column :addresses, :last_visited_by_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151118144034) do
+ActiveRecord::Schema.define(version: 20151123090947) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,6 +61,7 @@ ActiveRecord::Schema.define(version: 20151118144034) do
     t.string   "usps_verified_zip"
     t.string   "best_canvass_response",       default: "not_yet_visited"
     t.string   "last_canvass_response",       default: "unknown"
+    t.integer  "last_visited_by_id"
   end
 
   create_table "devices", force: :cascade do |t|

--- a/lib/ground_game/scenario/create_visit.rb
+++ b/lib/ground_game/scenario/create_visit.rb
@@ -42,6 +42,7 @@ module GroundGame
 
           address = create_or_update_address(address_params, visit)
           address.visited_at = DateTime.now
+          address.last_visited_by = user
 
           people = create_or_update_people_for_address(people_params, address, visit)
 

--- a/spec/lib/ground_game/scenario/create_visit_spec.rb
+++ b/spec/lib/ground_game/scenario/create_visit_spec.rb
@@ -71,6 +71,20 @@ module GroundGame
             expect(user.state_code).to eq "CA"
           end
 
+          it "sets the address 'last_visited_by' to the user creating the visit" do
+            user = create(:user, email: "josh@cookacademy.com")
+
+            address = create(:address, id: 1)
+            create(:person, id: 10, address: address, canvass_response: :unknown, party_affiliation: :unknown_affiliation)
+
+            visit_params = { duration_sec: 150 }
+            address_params = { id: 1 }
+            people_params = [{ id: 10 }]
+
+            result = CreateVisit.new(visit_params, address_params, people_params, user).call
+            expect(address.reload.last_visited_by_id).to eq user.id
+          end
+
           context "when the address already exists" do
 
             it "updates address.visited_at" do

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -14,17 +14,20 @@ describe Address do
     it {should have_db_column(:state_code).of_type(:string) }
     it {should have_db_column(:zip_code).of_type(:string) }
     it {should have_db_column(:visited_at).of_type(:datetime) }
-    it {should have_db_column(:most_supportive_resident_id).of_type(:integer) }
     it {should have_db_column(:usps_verified_street_1).of_type(:string) }
     it {should have_db_column(:usps_verified_city).of_type(:string) }
     it {should have_db_column(:usps_verified_zip).of_type(:string) }
     it {should have_db_column(:best_canvass_response).of_type(:string).with_options(default: "not_yet_visited") }
     it {should have_db_column(:last_canvass_response).of_type(:string).with_options(default: "unknown") }
+
+    it {should have_db_column(:most_supportive_resident_id).of_type(:integer) }
+    it {should have_db_column(:last_visited_by_id).of_type(:integer) }
   end
 
   context 'associations' do
     it { should have_many(:people) }
-    it { should belong_to(:most_supportive_resident) }
+    it { should belong_to(:most_supportive_resident).class_name("Person") }
+    it { should belong_to(:last_visited_by).class_name("User") }
   end
 
   context 'validations' do

--- a/spec/requests/api/address_spec.rb
+++ b/spec/requests/api/address_spec.rb
@@ -51,115 +51,112 @@ describe "Address API" do
         end
       end
 
-      context "when searching by parameters instead of radius" do
-        it "should return an error response when it fails", vcr: { cassette_name: "requests/api/addresses/succesful_easypost_response" }  do
-          authenticated_get "addresses", {
-            street_1: "5th Avenue",
-            city: "New York",
-            state_code: "NY"
-          }, token
+      context "when searching by parameters" do
+        context "and it fails" do
+          it "should return an error response", vcr: { cassette_name: "requests/api/addresses/succesful_easypost_response" }  do
+            authenticated_get "addresses", {
+              street_1: "5th Avenue",
+              city: "New York",
+              state_code: "NY"
+            }, token
 
-          expect(last_response.status).to eq 404
-          expect(json).to be_a_valid_json_api_error.with_id "ADDRESS_UNMATCHED"
+            expect(last_response.status).to eq 404
+            expect(json).to be_a_valid_json_api_error.with_id "ADDRESS_UNMATCHED"
+          end
         end
 
-        it "returns an existing address the address exists", vcr: { cassette_name: "requests/api/addresses/succesful_easypost_response" } do
-          address = create(:address,
-            id: 1,
-            latitude: 1,
-            longitude: 1,
-            street_1: "5th Avenue",
-            street_2: "",
-            city: "New York",
-            zip_code: "",
-            state_code: "NY",
-            usps_verified_street_1: "5 AVENUE A",
-            usps_verified_street_2: "",
-            usps_verified_city: "NEW YORK",
-            usps_verified_state: "NY",
-            usps_verified_zip: "10009-7944")
-          person = create(:person, id: 5, address: address, canvass_response: :strongly_for)
+        context "and it succeeds", vcr: { cassette_name: "requests/api/addresses/succesful_easypost_response" } do
+          before do
+            @address = create(:address,
+              id: 1,
+              latitude: 1,
+              longitude: 1,
+              street_1: "5th Avenue",
+              street_2: "",
+              city: "New York",
+              zip_code: "",
+              state_code: "NY",
+              usps_verified_street_1: "5 AVENUE A",
+              usps_verified_street_2: "",
+              usps_verified_city: "NEW YORK",
+              usps_verified_state: "NY",
+              usps_verified_zip: "10009-7944")
+          end
 
-          address.most_supportive_resident = person
-          address.best_canvass_response = person.canvass_response
-          address.save!
+          it "returns an existing address the address exists" do
 
-          authenticated_get "addresses", {
-            street_1: "5th Avenue",
-            city: "New York",
-            state_code: "NY"
-          }, token
+            person = create(:person, id: 5, address: @address, canvass_response: :strongly_for)
 
-          expect(last_response.status).to eq 200
-          expect(json.data.length).to eq 1
+            @address.most_supportive_resident = person
+            @address.best_canvass_response = person.canvass_response
+            @address.save!
 
-          address_json = json.data[0]
-          address_attributes = address_json.attributes
+            authenticated_get "addresses", {
+              street_1: "5th Avenue",
+              city: "New York",
+              state_code: "NY"
+            }, token
 
-          expect(address_attributes.latitude).to eq 1.0
-          expect(address_attributes.longitude).to eq 1.0
-          expect(address_attributes.street_1).to eq "5th Avenue"
-          expect(address_attributes.street_2).to eq ""
-          expect(address_attributes.city).to eq "New York"
-          expect(address_attributes.state_code).to eq "NY"
-          expect(address_attributes.zip_code).to eq ""
-          expect(address_attributes.best_canvass_response).to eq "strongly_for"
-          expect(address_attributes.last_canvass_response).not_to be_nil
+            expect(last_response.status).to eq 200
+            expect(json.data.length).to eq 1
 
-          address_relationships = address_json.relationships
-          expect(address_relationships.most_supportive_resident.data.id).to eq "5"
-        end
+            address_json = json.data[0]
+            address_attributes = address_json.attributes
 
-        it "includes people with the response", vcr: { cassette_name: "requests/api/addresses/succesful_easypost_response" } do
-          address = create(:address,
-            street_1: "5th Avenue",
-            street_2: "",
-            city: "New York",
-            zip_code: "",
-            state_code: "NY")
-          person_a = create(:person, id: 5, address: address, canvass_response: :strongly_for)
-          person_b = create(:person, id: 6, address: address, canvass_response: :leaning_for)
+            expect(address_attributes.latitude).to eq 1.0
+            expect(address_attributes.longitude).to eq 1.0
+            expect(address_attributes.street_1).to eq "5th Avenue"
+            expect(address_attributes.street_2).to eq ""
+            expect(address_attributes.city).to eq "New York"
+            expect(address_attributes.state_code).to eq "NY"
+            expect(address_attributes.zip_code).to eq ""
+            expect(address_attributes.best_canvass_response).to eq "strongly_for"
+            expect(address_attributes.last_canvass_response).not_to be_nil
 
-          address.people = [person_a, person_b]
-          address.save!
+            address_relationships = address_json.relationships
+            expect(address_relationships.most_supportive_resident.data.id).to eq "5"
+          end
 
-          authenticated_get "addresses", {
-            street_1: "5th Avenue",
-            city: "New York",
-            state_code: "NY"
-          }, token
+          it "includes people with the response" do
+            person_a = create(:person, id: 5, address: @address, canvass_response: :strongly_for)
+            person_b = create(:person, id: 6, address: @address, canvass_response: :leaning_for)
 
-          address_relationships = json.data[0].relationships
-          expect(address_relationships.people.data.map(&:id)).to contain_exactly "5","6"
+            @address.people = [person_a, person_b]
+            @address.save!
 
-          expect(json.included.length).to eq 2
-          expect(json.included.all? { |person| person.data.type == "people" }).to be true
-        end
+            authenticated_get "addresses", {
+              street_1: "5th Avenue",
+              city: "New York",
+              state_code: "NY"
+            }, token
 
-        it "includes the latest visitor with the response", vcr: { cassette_name: "requests/api/addresses/succesful_easypost_response" } do
-          visitor = create(:user, first_name: "Visitor")
-          address = create(:address,
-            street_1: "5th Avenue",
-            street_2: "",
-            city: "New York",
-            zip_code: "",
-            state_code: "NY",
-            last_visited_by: visitor)
+            address_relationships = json.data[0].relationships
+            expect(address_relationships.people.data.map(&:id)).to contain_exactly "5","6"
 
-          authenticated_get "addresses", {
-            street_1: "5th Avenue",
-            city: "New York",
-            state_code: "NY"
-          }, token
+            expect(json.included.length).to eq 2
+            expect(json.included.all? { |person| person.type == "people" }).to be true
+          end
 
-          expect(last_response.status).to eq 200
+          it "includes the latest visitor with the response" do
+            visitor = create(:user, first_name: "Visitor")
+            @address.last_visited_by = visitor
+            @address.save!
 
-          address_relationships = json.data[0].relationships
-          expect(address_relationships.last_visited_by.data.id).to eq visitor.id.to_s
+            authenticated_get "addresses", {
+              street_1: "5th Avenue",
+              city: "New York",
+              state_code: "NY"
+            }, token
 
-          expect(json.included.length).to eq 1
-          expect(json.included.first.data.type).to eq "users"
-          expect(json.included.first.data.attributes.first_name).to eq "Visitor"
+            expect(last_response.status).to eq 200
+
+            address_relationships = json.data[0].relationships
+            expect(address_relationships.last_visited_by.data.id).to eq visitor.id.to_s
+
+            expect(json.included.length).to eq 1
+            expect(json.included.first.type).to eq "users"
+            expect(json.included.first.attributes.first_name).to eq "Visitor"
+          end
         end
       end
     end

--- a/spec/requests/api/address_spec.rb
+++ b/spec/requests/api/address_spec.rb
@@ -17,25 +17,42 @@ describe "Address API" do
         create(:user, email: "test-user@mail.com", password: "password")
       end
 
-      it "returns a list of addresses within the specified radius of the specified point" do
-        create(:address, latitude: 1, longitude: 1)
-        create(:address, latitude: -1, longitude: -1)
-        create(:address, latitude: -1, longitude: 1)
-        create(:address, latitude: 1, longitude: -1)
-        create(:address, latitude: 20, longitude: 20)
+      context "when searching by radius" do
+        it "returns a list of addresses within the specified radius of the specified point" do
+          create(:address, latitude: 1, longitude: 1)
+          create(:address, latitude: -1, longitude: -1)
+          create(:address, latitude: -1, longitude: 1)
+          create(:address, latitude: 1, longitude: -1)
+          create(:address, latitude: 20, longitude: 20)
 
-        authenticated_get "addresses", {
-          latitude: 0,
-          longitude: 0,
-          radius: 200 * 1000
-        }, token
+          authenticated_get "addresses", {
+            latitude: 0,
+            longitude: 0,
+            radius: 200 * 1000
+          }, token
 
-        expect(last_response.status).to eq 200
-        expect(json.data.length).to eq 4
+          expect(last_response.status).to eq 200
+          expect(json.data.length).to eq 4
+        end
+
+        it "includes 'last_visited_by' for addresses that have it" do
+          latest_visitor = create(:user, first_name: "Visitor")
+          create(:address, latitude: 1, longitude: 1, last_visited_by: latest_visitor)
+          create(:address, latitude: -1, longitude: -1)
+
+          authenticated_get "addresses", {
+            latitude: 0,
+            longitude: 0,
+            radius: 200 * 1000
+          }, token
+
+          expect(json.included.length).to eq 1
+          expect(json.included.first.attributes.first_name).to eq "Visitor"
+        end
       end
 
-      context "when searching by parameters instead of scope" do
-        it "should return an error response when it failes", vcr: { cassette_name: "requests/api/addresses/succesful_easypost_response" }  do
+      context "when searching by parameters instead of radius" do
+        it "should return an error response when it fails", vcr: { cassette_name: "requests/api/addresses/succesful_easypost_response" }  do
           authenticated_get "addresses", {
             street_1: "5th Avenue",
             city: "New York",
@@ -46,7 +63,7 @@ describe "Address API" do
           expect(json).to be_a_valid_json_api_error.with_id "ADDRESS_UNMATCHED"
         end
 
-        it "returns an existing address with people included if the address exists", vcr: { cassette_name: "requests/api/addresses/succesful_easypost_response" } do
+        it "returns an existing address the address exists", vcr: { cassette_name: "requests/api/addresses/succesful_easypost_response" } do
           address = create(:address,
             id: 1,
             latitude: 1,
@@ -61,12 +78,10 @@ describe "Address API" do
             usps_verified_city: "NEW YORK",
             usps_verified_state: "NY",
             usps_verified_zip: "10009-7944")
-          person_a = create(:person, id: 5, address: address, canvass_response: :strongly_for)
-          person_b = create(:person, id: 6, address: address, canvass_response: :leaning_for)
+          person = create(:person, id: 5, address: address, canvass_response: :strongly_for)
 
-          address.people = [person_a, person_b]
-          address.most_supportive_resident = person_a
-          address.best_canvass_response = person_a.canvass_response
+          address.most_supportive_resident = person
+          address.best_canvass_response = person.canvass_response
           address.save!
 
           authenticated_get "addresses", {
@@ -76,11 +91,11 @@ describe "Address API" do
           }, token
 
           expect(last_response.status).to eq 200
-
           expect(json.data.length).to eq 1
 
           address_json = json.data[0]
           address_attributes = address_json.attributes
+
           expect(address_attributes.latitude).to eq 1.0
           expect(address_attributes.longitude).to eq 1.0
           expect(address_attributes.street_1).to eq "5th Avenue"
@@ -90,12 +105,61 @@ describe "Address API" do
           expect(address_attributes.zip_code).to eq ""
           expect(address_attributes.best_canvass_response).to eq "strongly_for"
           expect(address_attributes.last_canvass_response).not_to be_nil
+
           address_relationships = address_json.relationships
           expect(address_relationships.most_supportive_resident.data.id).to eq "5"
+        end
+
+        it "includes people with the response", vcr: { cassette_name: "requests/api/addresses/succesful_easypost_response" } do
+          address = create(:address,
+            street_1: "5th Avenue",
+            street_2: "",
+            city: "New York",
+            zip_code: "",
+            state_code: "NY")
+          person_a = create(:person, id: 5, address: address, canvass_response: :strongly_for)
+          person_b = create(:person, id: 6, address: address, canvass_response: :leaning_for)
+
+          address.people = [person_a, person_b]
+          address.save!
+
+          authenticated_get "addresses", {
+            street_1: "5th Avenue",
+            city: "New York",
+            state_code: "NY"
+          }, token
+
+          address_relationships = json.data[0].relationships
           expect(address_relationships.people.data.map(&:id)).to contain_exactly "5","6"
+
           expect(json.included.length).to eq 2
-          expect(json.included.all? { |person| person.type == "people" }).to be true
-          expect(json.included.all? { |person| person.relationships.address.data.id == "1" }).to be true
+          expect(json.included.all? { |person| person.data.type == "people" }).to be true
+        end
+
+        it "includes the latest visitor with the response", vcr: { cassette_name: "requests/api/addresses/succesful_easypost_response" } do
+          visitor = create(:user, first_name: "Visitor")
+          address = create(:address,
+            street_1: "5th Avenue",
+            street_2: "",
+            city: "New York",
+            zip_code: "",
+            state_code: "NY",
+            last_visited_by: visitor)
+
+          authenticated_get "addresses", {
+            street_1: "5th Avenue",
+            city: "New York",
+            state_code: "NY"
+          }, token
+
+          expect(last_response.status).to eq 200
+
+          address_relationships = json.data[0].relationships
+          expect(address_relationships.last_visited_by.data.id).to eq visitor.id.to_s
+
+          expect(json.included.length).to eq 1
+          expect(json.included.first.data.type).to eq "users"
+          expect(json.included.first.data.attributes.first_name).to eq "Visitor"
         end
       end
     end

--- a/spec/serializers/address_serializer_spec.rb
+++ b/spec/serializers/address_serializer_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe AddressSerializer, :type => :serializer do
 
   context "individual resource representation" do
-    let(:resource) { build(:address, :with_1_person) }
+    let(:resource) { build(:address, :with_1_person, last_visited_by: create(:user)) }
 
     let(:serializer) { AddressSerializer.new(resource) }
     let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer) }
@@ -107,7 +107,7 @@ describe AddressSerializer, :type => :serializer do
         it "should not be empty" do
           expect(subject).not_to be_nil
           expect(subject.first["id"]).not_to be nil
-          expect(subject.first["type"]).to eq "scores"
+          expect(subject.first["type"]).to eq "users"
         end
       end
 

--- a/spec/serializers/address_serializer_spec.rb
+++ b/spec/serializers/address_serializer_spec.rb
@@ -89,15 +89,37 @@ describe AddressSerializer, :type => :serializer do
         expect(subject["most_supportive_resident"]).not_to be_nil
         expect(subject["most_supportive_resident"]["data"]["id"]).to eq resource.most_supportive_resident_id.to_s
       end
+
+      it "should include a 'last_visited_by' relationship" do
+        expect(subject["last_visited_by"]).not_to be_nil
+        expect(subject["last_visited_by"]["data"]["id"]).to eq resource.last_visited_by_id.to_s
+      end
     end
 
     context "includes" do
-      subject do
-        JSON.parse(serialization.to_json)["data"]["includes"]
+      context "when including 'last_visited_by'" do
+        let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer, include: ["last_visited_by"]) }
+
+        subject do
+          JSON.parse(serialization.to_json)["included"]
+        end
+
+        it "should not be empty" do
+          expect(subject).not_to be_nil
+          expect(subject.first["id"]).not_to be nil
+          expect(subject.first["type"]).to eq "scores"
+        end
       end
 
-      it "should be empty" do
-        expect(subject).to be_nil
+      context "when not including anything" do
+
+        subject do
+          JSON.parse(serialization.to_json)["included"]
+        end
+
+        it "should be empty" do
+          expect(subject).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
-  [Asana task: Add last visited by to API](https://app.asana.com/0/52390949460913/67737723075990)
# Description

Adds a "last_visited_by_id" field to the addresses table, which includes a belongs_to relationship on the model. The field is nullable.
## Behavior
- Searching addresses by radius on the Address API endpoint includes the "last_visited_by" record if it exists.
- Searching addresses by address parameters also includes the record
- When creating a visit, regardless of the address being created or just updated, `address.last_visited_by` is assigned to the `user` passed into the scenario.
