### PR TITLE
Make api errors more explicit

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,7 +33,7 @@ class ApplicationController < ActionController::API
   end
 
   def render_validation_errors errors
-    error_hash = ErrorSerializer.serialize_validation_errors errors
+    error_hash = ErrorSerializer.serialize errors
     render json: error_hash, status: error_hash[:errors][0][:status]
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,7 +33,8 @@ class ApplicationController < ActionController::API
   end
 
   def render_validation_errors errors
-    render json: {errors: errors.to_h}, status: 422
+    error_hash = ErrorSerializer.serialize_validation_errors errors
+    render json: error_hash, status: error_hash[:errors][0][:status]
   end
 
   private

--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -22,8 +22,4 @@ class DevicesController < ApplicationController
       :token, :enabled, :platform
     ).merge(user_id: current_user.id)
   end
-
-  def render_validation_errors errors
-    render json: {errors: errors.to_h}, status: 422
-  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -88,8 +88,4 @@ class UsersController < ApplicationController
     user_params[:base_64_photo_data].present?
   end
 
-  def render_validation_errors errors
-    render json: {errors: errors.to_h}, status: 422
-  end
-
 end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -7,6 +7,19 @@ class ErrorSerializer
     { errors: [serialize_error(error)] }
   end
 
+  def self.serialize_validation_errors(errors)
+    return if errors.nil?
+
+    json = {}
+    new_hash = errors.to_hash(true).map do |k, v|
+      v.map do |msg|
+        { id: "VALIDATION_ERROR", title: "#{k.capitalize} error", detail: msg, status: 422 }
+      end
+    end.flatten
+    json[:errors] = new_hash
+    json
+  end
+
   private
 
     def self.serialize_error(error)

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -4,35 +4,21 @@ require "ground_game/easypost_error_adapter"
 
 class ErrorSerializer
   def self.serialize(error)
-    { errors: [serialize_error(error)] }
-  end
+    error_hash = serialize_argument_error(error) if error.class == ArgumentError
+    error_hash = serialize_record_not_found_error(error) if error.class == ActiveRecord::RecordNotFound
+    error_hash = serialize_visit_not_allowed_error(error) if error.class == GroundGame::VisitNotAllowed
+    error_hash = serialize_invalid_best_canvass_response_error(error) if error.class == GroundGame::InvalidBestCanvassResponse
+    error_hash = serialize_easypost_error(error) if error.class == EasyPost::Error
+    error_hash = serialize_address_unmatched_error(error) if error.class == GroundGame::AddressUnmatched
+    error_hash = serialize_facebook_authentication_error(error) if error.class == Koala::Facebook::AuthenticationError
+    error_hash = serialize_doorkeeper_oauth_invalid_token_response(error) if error.class == Doorkeeper::OAuth::InvalidTokenResponse
+    error_hash = serialize_doorkeeper_oauth_error_response(error) if error.class == Doorkeeper::OAuth::ErrorResponse
+    error_hash = serialize_validation_errors(error) if error.class == ActiveModel::Errors
 
-  def self.serialize_validation_errors(errors)
-    return if errors.nil?
-
-    json = {}
-    new_hash = errors.to_hash(true).map do |k, v|
-      v.map do |msg|
-        { id: "VALIDATION_ERROR", title: "#{k.capitalize} error", detail: msg, status: 422 }
-      end
-    end.flatten
-    json[:errors] = new_hash
-    json
+    { errors: Array.wrap(error_hash) }
   end
 
   private
-
-    def self.serialize_error(error)
-      return serialize_argument_error(error) if error.class == ArgumentError
-      return serialize_record_not_found_error(error) if error.class == ActiveRecord::RecordNotFound
-      return serialize_visit_not_allowed_error(error) if error.class == GroundGame::VisitNotAllowed
-      return serialize_invalid_best_canvass_response_error(error) if error.class == GroundGame::InvalidBestCanvassResponse
-      return serialize_easypost_error(error) if error.class == EasyPost::Error
-      return serialize_address_unmatched_error(error) if error.class == GroundGame::AddressUnmatched
-      return serialize_facebook_authentication_error(error) if error.class == Koala::Facebook::AuthenticationError
-      return serialize_doorkeeper_oauth_invalid_token_response(error) if error.class == Doorkeeper::OAuth::InvalidTokenResponse
-      return serialize_doorkeeper_oauth_error_response(error) if error.class == Doorkeeper::OAuth::ErrorResponse
-    end
 
     def self.serialize_argument_error(error)
       {
@@ -114,5 +100,13 @@ class ErrorSerializer
         detail: error.description,
         status: 401
       }
+    end
+
+    def self.serialize_validation_errors(errors)
+      errors.to_hash(true).map do |k, v|
+        v.map do |msg|
+          { id: "VALIDATION_ERROR", title: "#{k.capitalize} error", detail: msg, status: 422 }
+        end
+      end.flatten
     end
 end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -354,8 +354,7 @@ describe "Users API" do
           }
 
           expect(last_response.status).to eq 422
-
-          expect(json.errors.password).to eq "can't be blank"
+          expect(json).to be_a_valid_json_api_error.with_id "VALIDATION_ERROR"
         end
       end
 
@@ -375,7 +374,7 @@ describe "Users API" do
 
           expect(last_response.status).to eq 422
 
-          expect(json.errors.email).to eq "has already been taken"
+          expect(json).to be_a_valid_json_api_error.with_id "VALIDATION_ERROR"
         end
       end
 


### PR DESCRIPTION
- [Asana task: Make API errors more explicit in APIError](https://app.asana.com/0/52390949460913/67737723075984)
# Description

I'm not sure if I'm understanding the task completely, but the changes here should improve things at least a bit.

For now, the changes here at least make it so that the `ActiveModel::Error` format of validation errors passes through our `ErrorSerializer` and  gets converted into the proper json api format. 

The format is as follows:

``` Ruby
{
  id: "VALIDATION_ERROR",
  title: "#{attribute_name.capitalize} error",
  detail: "actual error text",
  status: 422
}
```
