### PR TITLE
Changes required to theoretically make clodfront query forwarding work

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ActiveRecord::Base
                       thumb: "150x150#",
                       large: "500x500#"
                     },
-                    path: "users/:id/:style-:suffix.:extension",
+                    path: "users/:id/:style.:extension",
                     default_url: ASSET_HOST_FOR_DEFAULT_PHOTO + '/default_:style.png'
 
   validates_attachment_content_type :photo,
@@ -80,12 +80,5 @@ class User < ActiveRecord::Base
     data.original_filename = SecureRandom.hex + '.png'
     data.content_type = 'image/png'
     self.photo = data
-  end
-
-  # We version the photo with a timestamp suffix
-  # which prevents issues with old photos showing due
-  # to remaining on CloudFront edge servers
-  Paperclip.interpolates :suffix  do |attachment, style|
-    attachment.updated_at.to_s
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -61,6 +61,16 @@ describe User do
       it 'should have the right path' do
         expect(@user.photo.url(:thumb)).to include "users/#{@user.id}/thumb"
       end
+
+      it 'should change the full url when the photo gets modified' do
+        old_url = @user.photo.url
+        allow(Time).to receive(:now).and_return(Time.now + 1.second)
+        # this simulates a reprocessing of the photo, while skiping the actual request
+        @user.photo.send(:assign_timestamps)
+        @user.photo.send(:save)
+        new_url = @user.photo.url
+        expect(new_url).not_to eq old_url
+      end
     end
   end
 


### PR DESCRIPTION
- [Asana task: Find a better replacement for photo updated at in suffix](https://app.asana.com/0/60127409159606/67942110850005)

In theory, with these changes (timestamps are enabled by default) and enabling of query forwarding on cloudfront, image caching should work properly.
