### PR TITLE
Added validation for user first and last name

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,9 @@ class User < ActiveRecord::Base
   validates_uniqueness_of :email, case_sensitive: false
   validates_uniqueness_of :facebook_id, allow_nil: true
 
+  validates_presence_of :first_name
+  validates_presence_of :last_name
+
   def self.friendly_token
     # Borrowed from Devise.friendly_token
     SecureRandom.urlsafe_base64(15).tr('lIO0', 'sxyz').first(12)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -39,6 +39,9 @@ describe User do
     it { should validate_presence_of(:password) }
     it { should validate_uniqueness_of(:email).case_insensitive }
     it { should validate_uniqueness_of(:facebook_id).allow_nil }
+
+    it { should validate_presence_of(:first_name) }
+    it { should validate_presence_of(:last_name) }
   end
 
   context 'paperclip' do


### PR DESCRIPTION
Closes #88 

This PR adds presence validation to user first and last name. Outside of that, I'm leaning against any other type of validation for names, because it's basically impossible.

Best thing I can think of we could do is maybe prevent common "fake" inputs, such as multiple repeat characters, "asdf", etc., but I don't think even that is worth it.
