### PR TITLE
Address validation

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -58,14 +58,19 @@ class Address < ActiveRecord::Base
     string_value
   end
 
+  validates :street_1, presence: true
+
   validates :latitude,
     presence: true,
     numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90 }
   validates :longitude,
     presence: true,
     numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 }
+
   validates :state_code, presence: true
-  validates :city, presence: true
+
+  validates_presence_of :city, unless: proc{|a| a.zip_code.present?}, message: "can't be empty if zip code is empty"
+  validates_presence_of :zip_code, unless: proc{|a| a.city.present?}, message: "can't be empty if city is empty"
 
   def assign_most_supportive_resident(person)
     current_best = self.most_supportive_resident
@@ -89,4 +94,5 @@ class Address < ActiveRecord::Base
     invalid_interval = lower_bound..upper_bound
     invalid_interval.include? self.visited_at.to_i
   end
+
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -58,8 +58,12 @@ class Address < ActiveRecord::Base
     string_value
   end
 
-  validates :latitude, presence: true
-  validates :longitude, presence: true
+  validates :latitude,
+    presence: true,
+    numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90 }
+  validates :longitude,
+    presence: true,
+    numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 }
   validates :state_code, presence: true
   validates :city, presence: true
 

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -58,7 +58,10 @@ class Address < ActiveRecord::Base
     string_value
   end
 
+  validates :latitude, presence: true
+  validates :longitude, presence: true
   validates :state_code, presence: true
+  validates :city, presence: true
 
   def assign_most_supportive_resident(person)
     current_best = self.most_supportive_resident

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -33,10 +33,11 @@ describe Address do
   end
 
   context 'validations' do
+    it { should validate_presence_of(:street_1) }
+    it { should validate_presence_of(:state_code) }
+
     it { should validate_presence_of(:latitude) }
     it { should validate_presence_of(:longitude) }
-    it { should validate_presence_of(:city) }
-    it { should validate_presence_of(:state_code) }
 
     it { should validate_numericality_of(:latitude).
       is_greater_than_or_equal_to(-90).
@@ -44,6 +45,13 @@ describe Address do
     it { should validate_numericality_of(:longitude).
       is_greater_than_or_equal_to(-180).
       is_less_than_or_equal_to(180) }
+
+    it "should require at least city or zip code" do
+      expect(build(:address, zip_code: nil, city: "Something")).to be_valid
+      expect(build(:address, zip_code: "ABC", city: nil)).to be_valid
+      expect(build(:address, zip_code: "ABC", city: "Something")).to be_valid
+      expect(build(:address, zip_code: nil, city: nil)).not_to be_valid
+    end
   end
 
   context 'scopes' do

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -37,6 +37,13 @@ describe Address do
     it { should validate_presence_of(:longitude) }
     it { should validate_presence_of(:city) }
     it { should validate_presence_of(:state_code) }
+
+    it { should validate_numericality_of(:latitude).
+      is_greater_than_or_equal_to(-90).
+      is_less_than_or_equal_to(90) }
+    it { should validate_numericality_of(:longitude).
+      is_greater_than_or_equal_to(-180).
+      is_less_than_or_equal_to(180) }
   end
 
   context 'scopes' do

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -6,22 +6,24 @@ describe Address do
   end
 
   context 'schema' do
-    it {should have_db_column(:latitude).of_type(:float) }
-    it {should have_db_column(:longitude).of_type(:float) }
-    it {should have_db_column(:street_1).of_type(:string) }
-    it {should have_db_column(:street_2).of_type(:string) }
-    it {should have_db_column(:city).of_type(:string) }
-    it {should have_db_column(:state_code).of_type(:string) }
-    it {should have_db_column(:zip_code).of_type(:string) }
-    it {should have_db_column(:visited_at).of_type(:datetime) }
-    it {should have_db_column(:usps_verified_street_1).of_type(:string) }
-    it {should have_db_column(:usps_verified_city).of_type(:string) }
-    it {should have_db_column(:usps_verified_zip).of_type(:string) }
-    it {should have_db_column(:best_canvass_response).of_type(:string).with_options(default: "not_yet_visited") }
-    it {should have_db_column(:last_canvass_response).of_type(:string).with_options(default: "unknown") }
+    it { should have_db_column(:latitude).of_type(:float) }
+    it { should have_db_column(:longitude).of_type(:float) }
+    it { should have_db_column(:street_1).of_type(:string) }
+    it { should have_db_column(:street_2).of_type(:string) }
+    it { should have_db_column(:city).of_type(:string) }
+    it { should have_db_column(:state_code).of_type(:string) }
+    it { should have_db_column(:zip_code).of_type(:string) }
+    it { should have_db_column(:visited_at).of_type(:datetime) }
+    it { should have_db_column(:usps_verified_street_1).of_type(:string) }
+    it { should have_db_column(:usps_verified_street_2).of_type(:string) }
+    it { should have_db_column(:usps_verified_city).of_type(:string) }
+    it { should have_db_column(:usps_verified_zip).of_type(:string) }
+    it { should have_db_column(:usps_verified_state).of_type(:string) }
+    it { should have_db_column(:best_canvass_response).of_type(:string).with_options(default: "not_yet_visited") }
+    it { should have_db_column(:last_canvass_response).of_type(:string).with_options(default: "unknown") }
 
-    it {should have_db_column(:most_supportive_resident_id).of_type(:integer) }
-    it {should have_db_column(:last_visited_by_id).of_type(:integer) }
+    it { should have_db_column(:most_supportive_resident_id).of_type(:integer) }
+    it { should have_db_column(:last_visited_by_id).of_type(:integer) }
   end
 
   context 'associations' do
@@ -31,6 +33,9 @@ describe Address do
   end
 
   context 'validations' do
+    it { should validate_presence_of(:latitude) }
+    it { should validate_presence_of(:longitude) }
+    it { should validate_presence_of(:city) }
     it { should validate_presence_of(:state_code) }
   end
 


### PR DESCRIPTION
Closes #87 

Validations:
- `street_1` is required
- `state_code` is required (already existed as validation)
- either `city` or `zip_code` or both are required (see note)
- `latitude` is required, validates numericality, range -90, 90, edges included
- `longitude` is required, validates numericality, range -180, 180, edges included
### Note on `street_1`, `state_code`, `city`, `zip_code`

When verifying an address through easypost, we need to provide a street, a state code and then either a city, or a zip code, or both, so I'm thinking maybe our model should follow the same logic. For that purpose, I added `unless` options to presence validation for city and zip code.
