### PR TITLE
force ssl in production (and test) environment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -60,4 +60,6 @@ Rails.application.configure do
     Bullet.bullet_logger = true
     Bullet.raise = true
   end
+
+  config.force_ssl = true
 end

--- a/spec/config/application_spec.rb
+++ b/spec/config/application_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe GroundGame::Application, 'configuration' do
+  let(:config) { described_class.config }
+
+  it "has the the environment properly set up to use ssl" do
+    # I could not find a way to load configuration for another environment.
+    # However, if production is properly set up, this test should pass on staging
+    # If it doesn't, it means we did not set up config to use ssl on production
+    expect(config.force_ssl).to be true
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,7 +43,7 @@ RSpec.configure do |config|
   end
 
   def host
-    "http://api.lvh.me:3000"
+    "https://api.lvh.me:3000"
   end
 
   def authenticated_get(path, args, token)


### PR DESCRIPTION
- [Asana task: Add force SSL](https://app.asana.com/0/60127409159606/69345053075499)

Prior to Rails 3.1, we had to use the rack ssl enforcer gem to achieve this, but it loos like it now suffices to set `config.force_ssl = true` in the proper environment configuration.

In this case, I have added this option to the test and the production environment. I also changed our host variable in the test environment to use `https`, so we know our specs will run.

Finally, I added an application config spec, which ensures the `force_ssl` variable is set. I cannot check if it's set for a specific environment, but my logic is, when the tests run on staging, they will fail if the variable is not set properly and pass otherwise, so that should suffice as a test.

If that logic is not sound, then we should add a spec which somehow checks if `force_ssl` for production is true, but outside of some heavy reflection, I'm not sure we can do that in a nice way.
