### PR TITLE
Remove duplicate uniqueness validation on users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,6 @@ class User < ActiveRecord::Base
   validates_attachment_content_type :photo,
                                     content_type: %r{^image\/(png|gif|jpeg)}
 
-  validates_uniqueness_of :email, case_sensitive: false
   validates_uniqueness_of :facebook_id, allow_nil: true
 
   validates_presence_of :first_name


### PR DESCRIPTION
A uniqueness validation for the user `email` attribute has already been added by the `Clearance::User::Validations` module in [clearance/user.rb#L144-L148](https://github.com/thoughtbot/clearance/blob/3e9529a643cff20beb9bb49eacedb90dee49d465/lib/clearance/user.rb#L144-L148). Duplicating the validation rule was resulting in duplicate error responses from the API.

In addition, there is no need to specify a `case_sensitive` property for the uniqueness validation on _non-text_ columns (the email column type is `varchar`), as it is ignored.

This update removes the redundant uniqueness validation for `user#email`, therefore preventing multiple email validation errors that were occurring in API responses.

Closes #108
